### PR TITLE
Fix: Set editor zoom transformOrigin to center

### DIFF
--- a/src/client/components/InteractiveModule.tsx
+++ b/src/client/components/InteractiveModule.tsx
@@ -574,7 +574,7 @@ const InteractiveModule: React.FC<InteractiveModuleProps> = ({ initialData, isEd
                   className="min-w-full min-h-full"
                   style={{
                     transform: `scale(${viewportZoom})`,
-                    transformOrigin: '0 0',
+                    transformOrigin: 'center center',
                     transition: 'transform 0.3s ease-out',
                     width: viewportZoom > 1 ? `${100 * viewportZoom}%` : '100%',
                     height: viewportZoom > 1 ? `${100 * viewportZoom}%` : '100%',


### PR DESCRIPTION
Changed the transformOrigin property for the editor's viewport container from '0 0' to 'center center'.

This ensures that when you zoom in or out of the image in the editor, the scaling originates from the center of the image, keeping it centered within the viewport. The previous behavior caused the image to scale from the top-left corner, often moving the content off-screen.

The width and height attributes of the viewport container were already correctly set up to handle scrolling when the zoomed image is larger than the viewport.