### PR TITLE
I've removed the position section from the HotspotEditorModal.

### DIFF
--- a/src/client/components/HotspotEditorModal.tsx
+++ b/src/client/components/HotspotEditorModal.tsx
@@ -197,19 +197,6 @@ const HotspotEditorModal: React.FC<HotspotEditorModalProps> = ({
             {/* Appearance Tab */}
             {activeTab === 'appearance' && (
               <div className="space-y-6">
-                {/* Position info - read only */}
-                <div className="space-y-3">
-                  <h3 className="text-lg font-medium text-slate-900 dark:text-white">Position</h3>
-                  <div className="bg-slate-50 dark:bg-slate-800 rounded-lg p-4">
-                    <p className="text-sm text-slate-600 dark:text-slate-400">
-                      📍 Current position: {selectedHotspot.x.toFixed(1)}%, {selectedHotspot.y.toFixed(1)}%
-                    </p>
-                    <p className="text-xs text-slate-500 dark:text-slate-500 mt-1">
-                      💡 Drag the hotspot on the image to reposition
-                    </p>
-                  </div>
-                </div>
-
                 {/* Size */}
                 <div className="space-y-3">
                   <h3 className="text-lg font-medium text-slate-900 dark:text-white">Size</h3>


### PR DESCRIPTION
The position section, which displayed the x/y coordinates of the hotspot, has been removed from the HotspotEditorModal. This change was made because you will drag the hotspot to your desired location, making the explicit coordinates unnecessary.