### PR TITLE
Fix: Ensure correct hotspot color rendering by using hex values

### DIFF
--- a/src/client/components/HotspotViewer.tsx
+++ b/src/client/components/HotspotViewer.tsx
@@ -154,7 +154,7 @@ const HotspotViewer: React.FC<HotspotViewerProps> = ({
         className={dotClasses}
         aria-hidden="true"
         style={{
-          backgroundColor: baseColor.startsWith('bg-') ? undefined : baseColor,
+          backgroundColor: baseColor, // Directly use baseColor
           width: hotspotDimensions.width,
           height: hotspotDimensions.height,
           // For scaling ::after element. CSS variables are a clean way.

--- a/src/client/components/StreamlinedHotspotEditor.tsx
+++ b/src/client/components/StreamlinedHotspotEditor.tsx
@@ -23,8 +23,14 @@ interface StreamlinedHotspotEditorProps {
 
 // Color preset options
 const COLOR_PRESETS = [
-  'bg-red-500', 'bg-blue-500', 'bg-green-500', 'bg-yellow-500', 
-  'bg-purple-500', 'bg-pink-500', 'bg-indigo-500', 'bg-cyan-500'
+  { name: 'Red', value: '#EF4444' },
+  { name: 'Blue', value: '#3B82F6' },
+  { name: 'Green', value: '#22C55E' },
+  { name: 'Yellow', value: '#EAB308' },
+  { name: 'Purple', value: '#8B5CF6' },
+  { name: 'Pink', value: '#EC4899' },
+  { name: 'Indigo', value: '#6366F1' },
+  { name: 'Cyan', value: '#06B6D4' }
 ];
 
 const StreamlinedHotspotEditor: React.FC<StreamlinedHotspotEditorProps> = ({
@@ -212,18 +218,20 @@ const StreamlinedHotspotEditor: React.FC<StreamlinedHotspotEditorProps> = ({
                 <label className="block text-xs text-slate-400 mb-1">Color</label>
                 <div className="relative">
                   <select
-                    value={selectedHotspot.color || 'bg-blue-500'}
+                    value={selectedHotspot.color || '#3B82F6'} // Default to a hex blue
                     onChange={(e) => handleHotspotUpdate({ color: e.target.value })}
                     className="w-full bg-slate-700 border border-slate-600 rounded px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 appearance-none"
                   >
                     {COLOR_PRESETS.map(color => (
-                      <option key={color} value={color}>
-                        {color.replace('bg-', '').replace('-500', '')}
+                      <option key={color.name} value={color.value}>
+                        {color.name}
                       </option>
                     ))}
                   </select>
-                  <div 
-                    className={`absolute right-8 top-1/2 transform -translate-y-1/2 w-4 h-4 rounded-full ${selectedHotspot.color || 'bg-blue-500'}`}
+                  {/* The visual preview div will be updated in the next step */}
+                  <div
+                    className="absolute right-8 top-1/2 transform -translate-y-1/2 w-4 h-4 rounded-full"
+                    style={{ backgroundColor: selectedHotspot.color || '#3B82F6' }} // Default to hex blue
                   />
                 </div>
               </div>

--- a/src/client/components/StreamlinedHotspotEditor.tsx
+++ b/src/client/components/StreamlinedHotspotEditor.tsx
@@ -33,6 +33,8 @@ const COLOR_PRESETS = [
   { name: 'Cyan', value: '#06B6D4' }
 ];
 
+const DEFAULT_HOTSPOT_COLOR_HEX = '#3B82F6'; // New constant
+
 const StreamlinedHotspotEditor: React.FC<StreamlinedHotspotEditorProps> = ({
   selectedHotspot,
   relatedEvents,
@@ -218,7 +220,7 @@ const StreamlinedHotspotEditor: React.FC<StreamlinedHotspotEditorProps> = ({
                 <label className="block text-xs text-slate-400 mb-1">Color</label>
                 <div className="relative">
                   <select
-                    value={selectedHotspot.color || '#3B82F6'} // Default to a hex blue
+                    value={selectedHotspot.color || DEFAULT_HOTSPOT_COLOR_HEX} // Use constant
                     onChange={(e) => handleHotspotUpdate({ color: e.target.value })}
                     className="w-full bg-slate-700 border border-slate-600 rounded px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 appearance-none"
                   >
@@ -231,7 +233,7 @@ const StreamlinedHotspotEditor: React.FC<StreamlinedHotspotEditorProps> = ({
                   {/* The visual preview div will be updated in the next step */}
                   <div
                     className="absolute right-8 top-1/2 transform -translate-y-1/2 w-4 h-4 rounded-full"
-                    style={{ backgroundColor: selectedHotspot.color || '#3B82F6' }} // Default to hex blue
+                    style={{ backgroundColor: selectedHotspot.color || DEFAULT_HOTSPOT_COLOR_HEX }} // Use constant
                   />
                 </div>
               </div>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -17,7 +17,7 @@ export interface HotspotData {
   y: number; // percentage 0-100
   title: string;
   description: string;
-  color?: string; // e.g., 'bg-red-500'
+  color?: string; // e.g., '#FF0000' (hex color string)
   size?: HotspotSize; // Size of the hotspot marker, defaults to 'medium'
 }
 


### PR DESCRIPTION
The previous logic for `backgroundColor` in `HotspotViewer` would incorrectly result in a default blue color if `hotspot.color` was a Tailwind class (e.g., 'bg-red-500'). This was because it would set `backgroundColor` to `undefined`, causing a fallback.

This commit addresses the issue by:
1. Updating the `HotspotData` type comment for `color` to specify that it should be a hex color string (e.g., "#FF0000").
2. Modifying `StreamlinedHotspotEditor.tsx`:
    - `COLOR_PRESETS` now store hex color values and user-friendly names instead of Tailwind classes.
    - The color selection dropdown saves the chosen hex color.
    - The color preview div uses inline styles with the hex color.
3. Simplifying the `backgroundColor` style in `HotspotViewer.tsx` to directly use the hex color string from `hotspot.color` or a default hex blue if undefined.

This ensures that hotspot colors are consistently applied as specified, resolving the bug where Tailwind classes would lead to an unintended default color.