### PR TITLE
Fix: Update HotspotViewer drag logic with safe math utils

### DIFF
--- a/src/client/components/HotspotViewer.tsx
+++ b/src/client/components/HotspotViewer.tsx
@@ -97,10 +97,6 @@ const HotspotViewer: React.FC<HotspotViewerProps> = ({
 
             const referenceRect = referenceElement.getBoundingClientRect();
             
-            if (!hasValidDimensions(referenceRect)) {
-              console.warn('Invalid reference rect dimensions during drag');
-              return;
-            }
             const percentDeltaX = safePercentageDelta(totalDeltaX, referenceRect, 'x');
             const percentDeltaY = safePercentageDelta(totalDeltaY, referenceRect, 'y');
             const newX = clamp(startHotspotX + percentDeltaX, 0, 100);

--- a/src/client/components/HotspotViewer.tsx
+++ b/src/client/components/HotspotViewer.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useRef } from 'react';
 import { HotspotData, HotspotSize } from '../../shared/types';
+import { safePercentageDelta, hasValidDimensions, clamp } from '../../lib/safeMathUtils';
 
 interface HotspotViewerProps {
   hotspot: HotspotData;
@@ -96,11 +97,14 @@ const HotspotViewer: React.FC<HotspotViewerProps> = ({
 
             const referenceRect = referenceElement.getBoundingClientRect();
             
-            const percentDeltaX = referenceRect.width > 0 ? (totalDeltaX / referenceRect.width) * 100 : 0;
-            const percentDeltaY = referenceRect.height > 0 ? (totalDeltaY / referenceRect.height) * 100 : 0;
-            
-            const newX = Math.max(0, Math.min(100, startHotspotX + percentDeltaX));
-            const newY = Math.max(0, Math.min(100, startHotspotY + percentDeltaY));
+            if (!hasValidDimensions(referenceRect)) {
+              console.warn('Invalid reference rect dimensions during drag');
+              return;
+            }
+            const percentDeltaX = safePercentageDelta(totalDeltaX, referenceRect, 'x');
+            const percentDeltaY = safePercentageDelta(totalDeltaY, referenceRect, 'y');
+            const newX = clamp(startHotspotX + percentDeltaX, 0, 100);
+            const newY = clamp(startHotspotY + percentDeltaY, 0, 100);
             
             onPositionChange(hotspot.id, newX, newY);
           };


### PR DESCRIPTION
Replaced unsafe division operations during hotspot dragging with safer utility functions (safePercentageDelta, hasValidDimensions, clamp) to prevent potential errors with invalid reference dimensions.