### PR TITLE
Fix: Correct trigger condition for Firebase live deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
           FIREBASE_CLI_EXPERIMENTS: webframeworks
 
   build_and_deploy:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref_name == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Changed the condition for the `build_and_deploy` job to use `github.event_name == 'push' && github.ref_name == 'main'`. This ensures the live deployment triggers specifically on push events to the main branch, providing a more robust and precise trigger mechanism.