### PR TITLE
Fix: Address memory leaks for Phase 1 Issue 1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,25 @@ After thorough analysis of the codebase, **67 specific bugs** have been identifi
 2. Use useRef for timeout IDs and clear in cleanup
 3. Ensure event listener removal in all code paths
 
+**Fixes Applied**:
+- **`src/client/components/InteractiveModule.tsx`**:
+    - Ensured `successMessageTimeoutRef` (for save success message) is cleared in `handleSave` and in `useEffect` cleanup (related to `initialData` changes).
+    - Ensured `applyTransformTimeoutRef` (for `applyTransform` function) is cleared in `applyTransform` and in `useEffect` cleanup (related to `initialData` changes).
+    - Ensured `debouncedApplyTransformTimeoutRef` (for `debouncedApplyTransform`) is cleared in `debouncedApplyTransform` and in a dedicated `useEffect` cleanup.
+    - Verified that the global keydown listener (`handleKeyDown`) was already correctly removed in `useEffect` cleanup.
+    - Verified that `pulseTimeoutRef` (for timeline event `PULSE_HOTSPOT`) was already correctly cleared in `useEffect` cleanup.
+    - Verified that `ResizeObserver` was already correctly disconnected in `useEffect` cleanup.
+    - Verified that `useAutoSave` hook's internal timer was already correctly cleared.
+- **`src/client/hooks/useTouchGestures.ts`**:
+    - `doubleTapTimeoutRef`: Added ref for the `setTimeout` in `handleTouchStart` (for double-tap zoom animation). Timeout is cleared if a new double-tap starts or in a `useEffect` cleanup on unmount.
+    - `touchEndTimeoutRef`: Added ref for the `setTimeout` in `handleTouchEnd` (for resetting transform state). Timeout is cleared if a new touch end starts or in a `useEffect` cleanup on unmount.
+- **`src/client/components/HotspotViewer.tsx`**:
+    - `holdTimeoutRef`: Ensured the `setTimeout` for hold-to-edit is cleared in `handlePointerUp`, if a drag starts, and in a `useEffect` cleanup on unmount.
+    - Document Event Listeners (`pointermove`, `pointerup`):
+        - Refactored `handlePointerDown` to use `useRef` for storing `pointerMove`, `pointerUp`, and `continueDrag` handler functions.
+        - Ensured these listeners are explicitly removed in the main `pointerUp` handler.
+        - Added a `useEffect` hook with an empty dependency array to remove any lingering document event listeners and clear `holdTimeoutRef` when the `HotspotViewer` component unmounts. This covers cases where the component might unmount mid-interaction.
+
 ### Issue 2: TypeScript Type Safety Violations
 **Priority**: CRITICAL - Runtime errors and type system bypass
 **Files**:

--- a/src/client/components/HotspotViewer.tsx
+++ b/src/client/components/HotspotViewer.tsx
@@ -23,9 +23,37 @@ const HotspotViewer: React.FC<HotspotViewerProps> = ({
   hotspot, isPulsing, isEditing, onFocusRequest, onPositionChange, isDimmedInEditMode, isContinuouslyPulsing, imageElement, pixelPosition, usePixelPositioning, onEditRequest, isMobile, onDragStateChange
 }) => {
   const [isDragging, setIsDragging] = useState(false);
+import React, { useState, useCallback, useRef, useEffect } from 'react';
+import { HotspotData, HotspotSize } from '../../shared/types';
+import { safePercentageDelta, clamp } from '../../lib/safeMathUtils';
+
+interface HotspotViewerProps {
+  hotspot: HotspotData;
+  isPulsing: boolean; // Timeline event driven pulse
+  isEditing: boolean;
+  onFocusRequest: (id: string) => void; // Callback to request focus/info display for this hotspot
+  onPositionChange?: (id: string, x: number, y: number) => void; // Callback for drag updates
+  isDimmedInEditMode?: boolean;
+  isContinuouslyPulsing?: boolean; // For idle mode gentle pulse
+  imageElement?: HTMLImageElement | null; // NEW PROP for editing mode
+  // NEW PROPS:
+  pixelPosition?: { x: number; y: number } | null;
+  usePixelPositioning?: boolean;
+  onEditRequest?: (id: string) => void; // Add edit callback
+  isMobile?: boolean;
+  onDragStateChange?: (isDragging: boolean) => void; // Callback for drag state changes
+}
+
+const HotspotViewer: React.FC<HotspotViewerProps> = ({
+  hotspot, isPulsing, isEditing, onFocusRequest, onPositionChange, isDimmedInEditMode, isContinuouslyPulsing, imageElement, pixelPosition, usePixelPositioning, onEditRequest, isMobile, onDragStateChange
+}) => {
+  const [isDragging, setIsDragging] = useState(false);
   const [isHolding, setIsHolding] = useState(false);
-  const holdTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const holdTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>();
   const dragThresholdRef = useRef(false);
+  const pointerMoveHandlerRef = useRef<((event: PointerEvent) => void) | null>(null);
+  const pointerUpHandlerRef = useRef<((event: PointerEvent) => void) | null>(null);
+  const continueDragHandlerRef = useRef<((event: PointerEvent) => void) | null>(null);
   
   // Get size classes based on hotspot size
   const getSizeClasses = (size: HotspotSize = 'medium') => {
@@ -77,15 +105,16 @@ const HotspotViewer: React.FC<HotspotViewerProps> = ({
     dragThresholdRef.current = false;
 
     // Start hold timer for edit
+    if (holdTimeoutRef.current) clearTimeout(holdTimeoutRef.current);
     holdTimeoutRef.current = setTimeout(() => {
       if (isHolding && !dragThresholdRef.current && onEditRequest) {
         setIsHolding(false);
         onEditRequest(hotspot.id);
-        return;
+        // No return here, allow subsequent cleanup
       }
     }, isMobile ? 400 : 600); // Hold time: 400ms for mobile, 600ms for desktop
 
-    const handlePointerMove = (moveEvent: PointerEvent) => {
+    pointerMoveHandlerRef.current = (moveEvent: PointerEvent) => {
       const deltaX = Math.abs(moveEvent.clientX - startX);
       const deltaY = Math.abs(moveEvent.clientY - startY);
       
@@ -106,7 +135,7 @@ const HotspotViewer: React.FC<HotspotViewerProps> = ({
           const startHotspotX = hotspot.x;
           const startHotspotY = hotspot.y;
           
-          const continueDrag = (dragEvent: PointerEvent) => {
+          continueDragHandlerRef.current = (dragEvent: PointerEvent) => {
             const totalDeltaX = dragEvent.clientX - startX;
             const totalDeltaY = dragEvent.clientY - startY;
             
@@ -123,35 +152,79 @@ const HotspotViewer: React.FC<HotspotViewerProps> = ({
             onPositionChange(hotspot.id, newX, newY);
           };
 
-          document.addEventListener('pointermove', continueDrag);
-          document.addEventListener('pointerup', () => {
-            setIsDragging(false);
-            onDragStateChange?.(false);
-            document.removeEventListener('pointermove', continueDrag);
-          }, { once: true });
+          if (continueDragHandlerRef.current) {
+            document.addEventListener('pointermove', continueDragHandlerRef.current);
+          }
+          // This specific pointerup for continueDrag is tricky with refs for removal in useEffect
+          // The {once: true} helps, but for robustness, we'll manage it via pointerUpHandlerRef
         }
       }
     };
 
-    const handlePointerUp = () => {
+    pointerUpHandlerRef.current = () => {
       if (holdTimeoutRef.current) {
         clearTimeout(holdTimeoutRef.current);
+        holdTimeoutRef.current = undefined;
       }
       setIsHolding(false);
       
+      if (isDragging) { // If it was a drag, setIsDragging and onDragStateChange handled by continueDrag's pointerup
+        setIsDragging(false); // Ensure this is set if drag didn't start but pointerup occurs
+        onDragStateChange?.(false);
+      }
+
       // If it was a quick tap without drag, show info
       if (!dragThresholdRef.current && Date.now() - startTime < 300) {
         onFocusRequest(hotspot.id);
       }
       
-      document.removeEventListener('pointermove', handlePointerMove);
-      document.removeEventListener('pointerup', handlePointerUp);
+      if (pointerMoveHandlerRef.current) {
+        document.removeEventListener('pointermove', pointerMoveHandlerRef.current);
+        pointerMoveHandlerRef.current = null;
+      }
+      if (pointerUpHandlerRef.current) { // Remove itself
+        document.removeEventListener('pointerup', pointerUpHandlerRef.current);
+        pointerUpHandlerRef.current = null;
+      }
+      if (continueDragHandlerRef.current) {
+        document.removeEventListener('pointermove', continueDragHandlerRef.current);
+        // No need to remove the specific pointerup for continueDrag if it was {once: true}
+        // and we handle general cleanup in pointerUpHandlerRef.current and useEffect
+        continueDragHandlerRef.current = null;
+      }
     };
 
-    document.addEventListener('pointermove', handlePointerMove);
-    document.addEventListener('pointerup', handlePointerUp);
-  }, [isEditing, isDragging, isHolding, onFocusRequest, onEditRequest, onPositionChange, hotspot, imageElement, onDragStateChange]);
+    if (pointerMoveHandlerRef.current) {
+      document.addEventListener('pointermove', pointerMoveHandlerRef.current);
+    }
+    if (pointerUpHandlerRef.current) {
+      document.addEventListener('pointerup', pointerUpHandlerRef.current);
+    }
+
+  }, [isEditing, isDragging, isHolding, onFocusRequest, onEditRequest, onPositionChange, hotspot, imageElement, onDragStateChange, isMobile]);
   
+  useEffect(() => {
+    // Cleanup function for the component unmounting
+    return () => {
+      if (holdTimeoutRef.current) {
+        clearTimeout(holdTimeoutRef.current);
+        holdTimeoutRef.current = undefined;
+      }
+      // Remove document event listeners if they are still active
+      if (pointerMoveHandlerRef.current) {
+        document.removeEventListener('pointermove', pointerMoveHandlerRef.current);
+      }
+      if (pointerUpHandlerRef.current) {
+        document.removeEventListener('pointerup', pointerUpHandlerRef.current);
+      }
+      if (continueDragHandlerRef.current) {
+        document.removeEventListener('pointermove', continueDragHandlerRef.current);
+        // If there was a specific pointerup for continueDrag, it should also be removed here
+        // However, the {once: true} strategy or general pointerUpHandlerRef should cover it.
+      }
+    };
+  }, []); // Empty dependency array ensures this runs on mount and unmount
+
   const timelinePulseClasses = isPulsing ? `animate-ping absolute inline-flex h-full w-full rounded-full ${baseColor} opacity-75` : '';
   const continuousPulseDotClasses = isContinuouslyPulsing ? 'subtle-pulse-animation' : '';
 


### PR DESCRIPTION
This commit resolves Issue 1 identified in CLAUDE.md, focusing on memory leaks caused by improper cleanup of event listeners and timeouts.

Key changes:
- InteractiveModule.tsx:
    - Ensured `setTimeout` for save success messages, `applyTransform`, and `debouncedApplyTransform` are cleared on component unmount or when new actions supersede them.
    - Verified existing cleanup for global keydown listeners, pulse timeouts, ResizeObserver, and auto-save timers.
- useTouchGestures.ts:
    - Ensured `setTimeout` calls for double-tap and touch-end transformations are cleared using refs and a `useEffect` cleanup hook, preventing leaks if the hook unmounts during these operations.
- HotspotViewer.tsx:
    - Ensured `setTimeout` for hold-to-edit functionality (`holdTimeoutRef`) is cleared on interaction completion/cancellation or component unmount.
    - Refactored document-level `pointermove` and `pointerup` event listeners (for drag and hold interactions) to use refs and be reliably removed via a `useEffect` cleanup and explicit removal in handler logic. This prevents listeners from persisting if the component unmounts mid-interaction.

These changes improve application stability and performance by preventing resource leaks.