### PR TITLE
Fix: Resolve hotspot dragging and click issues in editor

### DIFF
--- a/src/client/components/ImageEditCanvas.tsx
+++ b/src/client/components/ImageEditCanvas.tsx
@@ -224,6 +224,7 @@ const ImageEditCanvas: React.FC<ImageEditCanvasProps> = React.memo(({
                   onDragStateChange={onDragStateChange}
                   isContinuouslyPulsing={false} // Assuming this is for viewer mode, not editor
                   isMobile={isMobile}
+                  dragContainerRef={zoomedImageContainerRef} // Pass the ref here
                 />
               </div>
             ))}


### PR DESCRIPTION
- Modified HotspotViewer to accept a dragContainerRef prop to ensure drag calculations are relative to the correct container (zoomedImageContainerRef).
- Updated ImageEditCanvas to pass the zoomedImageContainerRef to HotspotViewer instances.
- This fixes an issue where hotspots were stuck at the bottom of the image, could only be dragged horizontally, and clicks wouldn't open the editor panel.
- The root cause was traced to drag calculations being relative to an incorrect, small wrapper div instead of the main image container.