### PR TITLE
Improve Hotspot Accessibility with ARIA and Announcements

### DIFF
--- a/src/client/components/HotspotViewer.tsx
+++ b/src/client/components/HotspotViewer.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useCallback } from 'react';
 import { HotspotData, HotspotSize } from '../../shared/types';
+import useScreenReaderAnnouncements from '../hooks/useScreenReaderAnnouncements';
 
 interface HotspotViewerProps {
   hotspot: HotspotData;
@@ -38,6 +39,7 @@ const HotspotViewer: React.FC<HotspotViewerProps> = (props) => {
 
   const [isDragging, setIsDragging] = useState(false);
   const [isHolding, setIsHolding] = useState(false);
+  const announce = useScreenReaderAnnouncements();
   const dragDataRef = useRef<{
     startX: number;
     startY: number;
@@ -127,6 +129,7 @@ const HotspotViewer: React.FC<HotspotViewerProps> = (props) => {
     if (!isDragging && (deltaX > threshold || deltaY > threshold)) {
       setIsDragging(true);
       setIsHolding(false);
+      announce('Drag started'); // Announce drag start
       if (onDragStateChange) onDragStateChange(true); // Notify parent about drag start
       if (holdTimeoutRef.current) {
         clearTimeout(holdTimeoutRef.current);
@@ -184,7 +187,10 @@ const HotspotViewer: React.FC<HotspotViewerProps> = (props) => {
     }
 
     // Clean up
-    if (isDragging && onDragStateChange) onDragStateChange(false); // Notify parent about drag end
+    if (isDragging) {
+      announce('Drag stopped'); // Announce drag stop
+      if (onDragStateChange) onDragStateChange(false); // Notify parent about drag end
+    }
     setIsDragging(false);
     setIsHolding(false);
     dragDataRef.current = null;
@@ -230,6 +236,9 @@ const HotspotViewer: React.FC<HotspotViewerProps> = (props) => {
       role="button"
       aria-label={`Hotspot: ${hotspot.title}${isEditing ? ' (drag to move, hold to edit)' : ''}`}
       tabIndex={0}
+      aria-pressed={isPulsing || isEditing} // Assuming isPulsing or active editing means "pressed"
+      aria-grabbed={isDragging}
+      aria-dropeffect={isDragging ? "move" : "none"}
     >
       <span className={dotClasses} aria-hidden="true">
         {isPulsing && <span className={timelinePulseClasses} aria-hidden="true"></span>}

--- a/src/client/hooks/useScreenReaderAnnouncements.ts
+++ b/src/client/hooks/useScreenReaderAnnouncements.ts
@@ -1,0 +1,85 @@
+import { useEffect, useCallback, useRef } from 'react';
+
+const visuallyHiddenStyle: React.CSSProperties = {
+  position: 'absolute',
+  overflow: 'hidden',
+  clip: 'rect(0 0 0 0)',
+  height: '1px',
+  width: '1px',
+  margin: '-1px',
+  padding: '0',
+  border: '0',
+};
+
+let liveRegionContainer: HTMLDivElement | null = null;
+
+function getLiveRegionContainer(): HTMLDivElement {
+  if (!liveRegionContainer) {
+    liveRegionContainer = document.createElement('div');
+    liveRegionContainer.id = 'screen-reader-announcements-container';
+    document.body.appendChild(liveRegionContainer);
+  }
+  return liveRegionContainer;
+}
+
+interface ScreenReaderAnnouncer {
+  (message: string, politeness?: 'polite' | 'assertive'): void;
+}
+
+/**
+ * Custom hook to provide screen reader announcements.
+ * Creates and manages a visually hidden ARIA live region.
+ *
+ * @returns A function to make announcements.
+ */
+function useScreenReaderAnnouncements(): ScreenReaderAnnouncer {
+  const announcerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = getLiveRegionContainer();
+    const announcerDiv = document.createElement('div');
+    announcerDiv.id = `sr-announcer-${Math.random().toString(36).substr(2, 9)}`;
+    Object.assign(announcerDiv.style, visuallyHiddenStyle);
+    // Default to assertive, can be changed by the announce function
+    announcerDiv.setAttribute('aria-live', 'assertive');
+    announcerDiv.setAttribute('aria-atomic', 'true');
+    container.appendChild(announcerDiv);
+    announcerRef.current = announcerDiv;
+
+    return () => {
+      if (announcerDiv) {
+        container.removeChild(announcerDiv);
+      }
+      // If this is the last announcer, remove the container
+      if (container.childElementCount === 0) {
+        document.body.removeChild(container);
+        liveRegionContainer = null;
+      }
+    };
+  }, []);
+
+  const announce = useCallback((message: string, politeness: 'polite' | 'assertive' = 'assertive') => {
+    if (announcerRef.current) {
+      // Update politeness if specified
+      if (announcerRef.current.getAttribute('aria-live') !== politeness) {
+        announcerRef.current.setAttribute('aria-live', politeness);
+      }
+      // Set text content to trigger announcement
+      // Using textContent is generally safer and more performant for text-only updates.
+      announcerRef.current.textContent = message;
+
+      // Optional: Clear after a short delay if messages might be similar and not re-announced.
+      // However, modern screen readers are usually good about re-announcing the same message
+      // if the content of an assertive live region is set again.
+      // setTimeout(() => {
+      //   if(announcerRef.current) {
+      //     announcerRef.current.textContent = '';
+      //   }
+      // }, 100); // Adjust delay as needed
+    }
+  }, []);
+
+  return announce;
+}
+
+export default useScreenReaderAnnouncements;


### PR DESCRIPTION
This commit addresses critical accessibility gaps in the HotspotViewer component (Issue #3 from CLAUDE.md) by:

1.  **Implementing missing ARIA attributes in `HotspotViewer.tsx`:**
    *   Added `aria-pressed` to indicate when a hotspot is active (pulsing or in edit mode).
    *   Added `aria-grabbed` to reflect the drag state of the hotspot.
    *   Added `aria-dropeffect="move"` during drag operations to specify the allowed drop effect.

2.  **Creating and integrating the `useScreenReaderAnnouncements.ts` hook:**
    *   Introduced a new hook (`src/client/hooks/useScreenReaderAnnouncements.ts`) that creates and manages an ARIA live region for screen reader announcements.
    *   The hook provides an `announce` function to send messages to the live region.
    *   Integrated this hook into `HotspotViewer.tsx` to announce "Drag started" and "Drag stopped" events, providing crucial feedback for users relying on screen readers during drag-and-drop interactions.

These changes significantly enhance the accessibility of hotspots, particularly for keyboard and screen reader users, by providing better semantic information and auditory feedback for dynamic interactions.