### PR TITLE
Refactor(MobileHotspotEditor): Debounce text inputs to improve UX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "interactive-training-module-creator",
       "version": "0.0.0",
       "dependencies": {
+        "@types/lodash.debounce": "^4.0.9",
         "firebase": "^11.9.1",
+        "lodash.debounce": "^4.0.8",
         "react": "^18.3.1",
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
@@ -2189,6 +2191,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash.debounce": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
+      "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.15.33",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.33.tgz",
@@ -3635,6 +3652,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
     "node_modules/long": {

--- a/package.json
+++ b/package.json
@@ -23,11 +23,13 @@
     "codespaces:preview": "npm run build && npm run firebase:serve"
   },
   "dependencies": {
+    "@types/lodash.debounce": "^4.0.9",
     "firebase": "^11.9.1",
+    "lodash.debounce": "^4.0.8",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
     "react-dnd": "^16.0.1",
-    "react-dnd-html5-backend": "^16.0.1"
+    "react-dnd-html5-backend": "^16.0.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",


### PR DESCRIPTION
Implemented debouncing for the title and description fields in the MobileHotspotEditor component.

Previously, the `onUpdate` callback was triggered on every keystroke for these text inputs. This could lead to performance degradation, especially on mobile devices, and potentially cause excessive network requests or state updates in parent components.

Changes made:
- Introduced `lodash.debounce` to delay the `onUpdate` call for `title` and `description` fields by 500ms.
- Ensured that the local `internalHotspot` state is updated immediately to maintain input field responsiveness for the user.
- Style-related fields (backgroundColor, size) continue to trigger `onUpdate` immediately as they are single-action changes.
- Added cleanup effects to cancel any pending debounced `onUpdate` calls when the component unmounts or when the input `hotspot` prop changes, preventing stale updates or updates on incorrect data.

This change enhances the user experience by making the mobile editor feel smoother and more performant, and reduces the frequency of parent component updates during text entry.