### PR TITLE
feat: Implement click-to-place for new hotspots

### DIFF
--- a/src/client/components/EditorToolbar.tsx
+++ b/src/client/components/EditorToolbar.tsx
@@ -37,6 +37,7 @@ interface EditorToolbarProps {
   showSuccessMessage: boolean;
   isMobile?: boolean; // Already present as per instructions
   onAddHotspot: () => void; // Prop for adding a hotspot
+  isPlacingHotspot?: boolean; // For visual feedback
 }
 
 const EditorToolbar: React.FC<EditorToolbarProps> = (props) => {
@@ -112,11 +113,15 @@ const EditorToolbar: React.FC<EditorToolbarProps> = (props) => {
           <div className="flex items-center gap-1">
             <button
               onClick={props.onAddHotspot}
-              className="flex items-center gap-1 text-slate-300 hover:text-white bg-slate-700 hover:bg-slate-600 px-2 py-1 rounded transition-colors"
-              title="Add Hotspot"
+              className={`flex items-center gap-1 px-2 py-1 rounded transition-colors ${
+                props.isPlacingHotspot
+                  ? 'bg-yellow-500 hover:bg-yellow-600 text-slate-900' // Styling for "placing" mode
+                  : 'bg-slate-700 hover:bg-slate-600 text-slate-300 hover:text-white' // Default styling
+              }`}
+              title={props.isPlacingHotspot ? "Cancel Placement - Click on Image" : "Add Hotspot"}
             >
               <PlusCircleIcon className="w-5 h-5" />
-              <span className="text-sm">Add</span>
+              <span className="text-sm">{props.isPlacingHotspot ? "Place..." : "Add"}</span>
             </button>
           </div>
 
@@ -180,11 +185,15 @@ const EditorToolbar: React.FC<EditorToolbarProps> = (props) => {
 
             <button
               onClick={props.onAddHotspot}
-              className="flex items-center gap-2 text-slate-300 hover:text-white bg-slate-700 hover:bg-slate-600 px-3 py-1.5 rounded-md transition-colors"
-              title="Add Hotspot"
+              className={`flex items-center gap-2 px-3 py-1.5 rounded-md transition-colors ${
+                props.isPlacingHotspot
+                  ? 'bg-yellow-500 hover:bg-yellow-600 text-slate-900' // Styling for "placing" mode
+                  : 'bg-slate-700 hover:bg-slate-600 text-slate-300 hover:text-white' // Default styling
+              }`}
+              title={props.isPlacingHotspot ? "Cancel Hotspot Placement" : "Add Hotspot"}
             >
               <PlusCircleIcon className="w-5 h-5" />
-              <span>Add Hotspot</span>
+              <span>{props.isPlacingHotspot ? "Click to Place Hotspot..." : "Add Hotspot"}</span>
             </button>
           </div>
 


### PR DESCRIPTION
Improves the user experience for adding new hotspots on desktop (and consistently on mobile) by changing the workflow from immediate modal opening to a two-step placement process:

1.  User clicks the "Add Hotspot" button, entering a "placement mode."
    - UI indicates this mode (cursor change, button text/style update).
2.  User clicks on the image canvas at the desired location for the new hotspot.
    - The hotspot is created at these coordinates.
    - The hotspot editor modal then opens for the newly placed hotspot.

This provides a more intuitive and direct way to position hotspots during their initial creation.

Key changes:
- Added `isPlacingHotspot` state to `InteractiveModule` to manage the placement mode.
- Modified `handleAddHotspot` in `InteractiveModule` to toggle placement mode.
- Implemented `handlePlaceNewHotspot` in `InteractiveModule` to create the hotspot data at the clicked coordinates and open the editor modal.
- Updated `ImageEditCanvas` to:
    - Accept `isPlacingHotspot` and `onPlaceNewHotspot` props.
    - Handle clicks when in placement mode to determine hotspot coordinates and call `onPlaceNewHotspot`.
    - Adjust cursor style during placement mode.
- Enhanced `EditorToolbar` to provide visual feedback (button text and style) when in placement mode.
- Implemented cancellation of placement mode:
    - Pressing the Escape key now cancels placement.
    - Clicking the "Add Hotspot" button again while in placement mode also cancels it.