### PR TITLE
Fix: Prevent input fields from disappearing in mobile editor

### DIFF
--- a/src/client/components/MobileEditorLayout.tsx
+++ b/src/client/components/MobileEditorLayout.tsx
@@ -103,9 +103,18 @@ const MobileEditorLayout: React.FC<MobileEditorLayoutProps> = ({
       });
 
       // Automatically switch layout modes based on available space
-      if (isKeyboardVisible) {
+      // Prevent switching to modal mode if the keyboard is visible AND the active panel is already 'properties'
+      // as this is where text input occurs and we want to keep the MobileHotspotEditor visible.
+      if (isKeyboardVisible && activePanel !== 'properties') {
         setEditorMode('modal');
+        // It might be disruptive to force activePanel to 'properties' here.
+        // Consider if this line is truly necessary or if the modal should be more generic.
+        // For now, keeping original logic if modal mode is entered for other reasons.
         setActivePanel('properties');
+      } else if (isKeyboardVisible && activePanel === 'properties') {
+        // If keyboard is visible and we are on the properties panel, stay in compact mode
+        // to allow MobileHotspotEditor to be used. The layout should adjust.
+        setEditorMode('compact');
       } else if (visualViewportHeight < 600) {
         setEditorMode('fullscreen');
       } else {


### PR DESCRIPTION
When editing hotspot properties (e.g., title, description) in the mobile editor, tapping on an input field would cause the virtual keyboard to appear. This, in turn, triggered a layout mode switch to a 'modal' state. However, this 'modal' layout was not fully implemented and did not render the actual input fields, effectively making them disappear and preventing text entry.

This commit addresses the issue by modifying the viewport detection logic in `MobileEditorLayout.tsx`. Now, if the keyboard becomes visible while the 'properties' panel (containing `MobileHotspotEditor`) is active, the editor no longer switches to the problematic 'modal' mode. Instead, it remains in the 'compact' layout mode.

The 'compact' layout is already designed to adjust to available viewport height (shrinking when the keyboard appears) and its child components (specifically the container for `MobileHotspotEditor` and the editor itself) utilize `overflow-y-auto` to ensure content remains scrollable and accessible. This change allows these existing mechanisms to function correctly, ensuring that input fields stay visible and usable when the keyboard is open on mobile devices.