### PR TITLE
Fix: Prevent mobile editor panel from switching on keyboard appearance

### DIFF
--- a/src/client/components/MobileEditorLayout.tsx
+++ b/src/client/components/MobileEditorLayout.tsx
@@ -110,7 +110,7 @@ const MobileEditorLayout: React.FC<MobileEditorLayoutProps> = ({
         // It might be disruptive to force activePanel to 'properties' here.
         // Consider if this line is truly necessary or if the modal should be more generic.
         // For now, keeping original logic if modal mode is entered for other reasons.
-        setActivePanel('properties');
+        // setActivePanel('properties'); // Removed this line to prevent forced panel switch
       } else if (isKeyboardVisible && activePanel === 'properties') {
         // If keyboard is visible and we are on the properties panel, stay in compact mode
         // to allow MobileHotspotEditor to be used. The layout should adjust.


### PR DESCRIPTION
Bug:
In the MobileEditorLayout, when the on-screen keyboard would appear (e.g., due to an accidental tap or browser feature) while the user had the 'image' or 'timeline' panel active, the layout logic would incorrectly force the active panel to 'properties' and switch the editorMode to 'modal'. This created a jarring user experience, causing a loss of context and interrupting the user's workflow. A comment in the code even hinted at this potentially disruptive behavior.

Fix:
Modified the `useEffect` hook within `MobileEditorLayout.tsx` that handles viewport changes. Specifically, the line `setActivePanel('properties');` was removed from the conditional block:

```typescript
if (isKeyboardVisible && activePanel !== 'properties') {
  setEditorMode('modal');
  // setActivePanel('properties'); // Removed this line
}
```

This change ensures that if the keyboard appears while the 'image' or 'timeline' panel is active, the `editorMode` may still adjust (e.g., to 'modal' to better utilize screen space), but the `activePanel` will remain as selected by the user. The editor will only switch to 'compact' mode (showing the properties editor) if the keyboard appears when the 'properties' panel is already active, which is the expected behavior for text input in that context.

This targeted fix enhances the mobile editor UI by making panel transitions more predictable and less disruptive, directly improving usability.