### PR TITLE
Fix: Prevent conflicting gestures on mobile hotspot interactions

### DIFF
--- a/src/client/components/HotspotViewer.tsx
+++ b/src/client/components/HotspotViewer.tsx
@@ -220,6 +220,8 @@ const HotspotViewer: React.FC<HotspotViewerProps> = (props) => {
 
   return (
     <div
+      // Add data-hotspot-id here for reliable touch target identification
+      data-hotspot-id={hotspot.id}
       className={`absolute group transform -translate-x-1/2 -translate-y-1/2 ${
         isDragging ? 'z-50' : 'z-20'
       } ${


### PR DESCRIPTION
This commit resolves a bug where interacting with the expanded touch area of a hotspot on mobile devices could lead to conflicting gestures. Specifically, the main image/container would attempt to pan/zoom while the user was trying to drag a hotspot.

The root cause was that the `isHotspotElement` check in the `useTouchGestures` hook failed to reliably identify touches originating on the hotspot's expanded touch area (created by a CSS pseudo-element). The event target for such touches could be the root `div` of the `HotspotViewer` component, which previously lacked a specific identifying attribute that `useTouchGestures` was looking for.

The fix involves adding the `data-hotspot-id={hotspot.id}` attribute to the root `div` of the `HotspotViewer` component. This ensures that `useTouchGestures` can correctly identify touches starting anywhere on the hotspot component, thereby preventing it from initiating container-level pan/zoom gestures when a hotspot interaction is intended.

This change enhances the mobile user experience by making hotspot manipulation more precise and predictable.