### PR TITLE
Fix: Ensure debounced text updates in MobileHotspotEditor are flushed…

### DIFF
--- a/src/client/components/MobileHotspotEditor.tsx
+++ b/src/client/components/MobileHotspotEditor.tsx
@@ -61,11 +61,12 @@ const MobileHotspotEditor: React.FC<MobileHotspotEditorProps> = ({ hotspot, onUp
       debouncedOnUpdate({ [field]: value });
     } else {
       // For non-text fields (color, size), update immediately
+      // First, flush any pending debounced text updates to ensure they are processed.
+      debouncedOnUpdate.flush();
+      // Then, apply the immediate update for the non-text field.
       onUpdate({ [field]: value });
-      // If there was a pending debounced update for text, it might be good to cancel it,
-      // or ensure the immediate update doesn't conflict.
-      // However, typical use case is editing text OR clicking a button, not simultaneously.
-      // For now, this should be fine.
+      // This addresses the concern about potential conflicts or lost updates if an
+      // immediate update interferes with a pending debounced update.
     }
   }, [onUpdate, debouncedOnUpdate]);
 


### PR DESCRIPTION
… before style changes

In MobileHotspotEditor.tsx, there was a potential issue where pending debounced text updates (for title or description) could be lost or conflict with immediate updates for style properties (like background color or size).

This could happen if a style change triggered a rapid state transition in the parent component (e.g., re-rendering with a new hotspot prop, or unmounting the editor) that interfered with the normal processing of the still-pending debounced text update. An existing code comment highlighted this as a potential area of concern.

This commit addresses the issue by explicitly calling `debouncedOnUpdate.flush()` in the `handleChange` function for non-text fields *before* the immediate `onUpdate()` call for the style change is made.

This ensures that any pending text modifications are sent to the parent component first, followed by the style modification. This serialization makes the update sequence more robust, reduces the chance of data loss for text inputs, and improves the overall reliability and user experience of the mobile hotspot editor.