### PR TITLE
Fix: Implement dynamic --vh CSS property for mobile viewport height

### DIFF
--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -10,6 +10,7 @@ import { appScriptProxy } from '../../lib/firebaseProxy';
 import { PlusCircleIcon } from './icons/PlusCircleIcon';
 import { useIsMobile } from '../hooks/useIsMobile';
 import SharedModuleViewer from './SharedModuleViewer';
+import { setDynamicVhProperty } from '../utils/mobileUtils';
 
 // Main App Component for the landing page
 const MainApp: React.FC = () => {
@@ -21,6 +22,16 @@ const MainApp: React.FC = () => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const isMobile = useIsMobile();
+
+  useEffect(() => {
+    // Set up the dynamic --vh property updater
+    const cleanupVhUpdater = setDynamicVhProperty();
+
+    // Cleanup function to remove event listeners when the component unmounts
+    return () => {
+      cleanupVhUpdater();
+    };
+  }, []); // Empty dependency array ensures this runs only once on mount and cleans up on unmount
 
   const loadProjects = useCallback(async () => {
     setIsLoading(true);

--- a/src/client/utils/mobileUtils.ts
+++ b/src/client/utils/mobileUtils.ts
@@ -56,3 +56,21 @@ export const getMobileSafeAreaInsets = () => {
     right: 'env(safe-area-inset-right, 0px)'
   };
 };
+
+export const setDynamicVhProperty = () => {
+  const updateVh = () => {
+    const vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty('--vh', `${vh}px`);
+  };
+
+  updateVh(); // Set initial value
+
+  window.addEventListener('resize', updateVh);
+  window.addEventListener('orientationchange', updateVh);
+
+  // Return a cleanup function to remove event listeners
+  return () => {
+    window.removeEventListener('resize', updateVh);
+    window.removeEventListener('orientationchange', updateVh);
+  };
+};


### PR DESCRIPTION
Previously, the `--vh` CSS custom property was initialized to `1vh` but was not dynamically updated. This meant that layouts relying on `calc(var(--vh, 1vh) * 100)` (intended to represent 100% of the viewport height) would not correctly adapt to mobile browser UI changes (e.g., address bar shrinking/growing) or the appearance of the on-screen keyboard.

This commit introduces a robust solution:

1.  Added `setDynamicVhProperty` utility in `src/client/utils/mobileUtils.ts`:
    *   Calculates `window.innerHeight * 0.01` to get a pixel value for 1% of the current viewport height.
    *   Sets this value to the `--vh` CSS custom property on the root element (`document.documentElement.style`).
    *   Attaches event listeners for `resize` and `orientationchange` to update the `--vh` property dynamically.
    *   Returns a cleanup function to remove these event listeners.

2.  Integrated into `App.tsx`:
    *   The `setDynamicVhProperty` function is called within a `useEffect` hook in the main `App` component.
    *   This ensures the `--vh` property is initialized on application load and kept up-to-date throughout the session.
    *   The cleanup function is used to remove event listeners when the application unmounts, preventing memory leaks.

This change ensures that CSS rules using `var(--vh)` (e.g., `height: calc(var(--vh) * 100)`) will now accurately reflect the true available viewport height on mobile devices, leading to more stable and predictable layouts.