### PR TITLE
Feat: Enhance hotspot placement with visual cues and right-click cancel

### DIFF
--- a/src/client/components/EditorToolbar.tsx
+++ b/src/client/components/EditorToolbar.tsx
@@ -124,7 +124,7 @@ const EditorToolbar: React.FC<EditorToolbarProps> = (props) => {
                   ? 'bg-yellow-500 hover:bg-yellow-600 text-slate-900' // Styling for "placing" mode
                   : 'bg-slate-700 hover:bg-slate-600 text-slate-300 hover:text-white' // Default styling
               }`}
-              title={props.isPlacingHotspot ? "Cancel Placement - Click on Image" : "Add Hotspot"}
+              title={props.isPlacingHotspot ? "Cancel Placement (or tap button again)" : "Add Hotspot"}
             >
               <PlusCircleIcon className="w-5 h-5" />
               <span className="text-sm">{props.isPlacingHotspot ? "Place..." : "Add"}</span>
@@ -207,7 +207,7 @@ const EditorToolbar: React.FC<EditorToolbarProps> = (props) => {
                   ? 'bg-yellow-500 hover:bg-yellow-600 text-slate-900' // Styling for "placing" mode
                   : 'bg-slate-700 hover:bg-slate-600 text-slate-300 hover:text-white' // Default styling
               }`}
-              title={props.isPlacingHotspot ? "Cancel Hotspot Placement" : "Add Hotspot"}
+              title={props.isPlacingHotspot ? "Cancel Placement (or right-click on image)" : "Add Hotspot"}
             >
               <PlusCircleIcon className="w-5 h-5" />
               <span>{props.isPlacingHotspot ? "Click to Place Hotspot..." : "Add Hotspot"}</span>

--- a/src/client/components/ImageEditCanvas.tsx
+++ b/src/client/components/ImageEditCanvas.tsx
@@ -64,6 +64,7 @@ interface ImageEditCanvasProps {
   // Props for "click to place" new hotspot
   isPlacingHotspot?: boolean;
   onPlaceNewHotspot?: (x: number, y: number) => void;
+  onCancelPlacement?: () => void; // New prop for cancelling placement
 }
 
 const ImageEditCanvas: React.FC<ImageEditCanvasProps> = React.memo(({
@@ -100,6 +101,7 @@ const ImageEditCanvas: React.FC<ImageEditCanvasProps> = React.memo(({
   imageFitMode,
   isPlacingHotspot = false,
   onPlaceNewHotspot,
+  onCancelPlacement,
 }) => {
   // Determine if dimming logic is applicable (simplified from InteractiveModule)
   const getIsHotspotDimmed = (hotspotId: string) => {
@@ -142,6 +144,281 @@ const ImageEditCanvas: React.FC<ImageEditCanvasProps> = React.memo(({
         cursor: isPlacingHotspot ? 'crosshair' : (isDragModeActive ? 'grabbing' : (isEditing && backgroundImage ? 'crosshair' : 'default')),
       }}
       onClick={(e) => {
+        // If currently placing a hotspot and the click is on the canvas background (not a hotspot itself)
+        if (isPlacingHotspot && onPlaceNewHotspot && actualImageRef.current) {
+          const target = e.target as HTMLElement;
+          // Check if the click was directly on the image or its container, not on a hotspot viewer
+          if (target === actualImageRef.current || target === zoomedImageContainerRef.current || target === scrollableContainerRef.current) {
+            const imageRect = actualImageRef.current.getBoundingClientRect();
+            const scrollRect = scrollableContainerRef.current?.getBoundingClientRect();
+
+            if (!scrollRect) return;
+
+            // Calculate click position relative to the scrollable container
+            const clickXInScrollContainer = e.clientX - scrollRect.left;
+            const clickYInScrollContainer = e.clientY - scrollRect.top;
+
+            // Account for current scroll position of the container
+            const scrollLeft = scrollableContainerRef.current?.scrollLeft || 0;
+            const scrollTop = scrollableContainerRef.current?.scrollTop || 0;
+
+            // Click position relative to the actual image element's top-left corner (considering its current display rect)
+            const clickXRelativeToImageOrigin = e.clientX - imageRect.left;
+            const clickYRelativeToImageOrigin = e.clientY - imageRect.top;
+
+            // Convert to coordinates on the unzoomed, natural-sized image
+            // The imageRect dimensions (width/height) are the displayed size, already affected by zoom.
+            // We need to map the click point (which is on the displayed image) back to the natural image.
+            const xOnNaturalImage = (clickXRelativeToImageOrigin / imageRect.width) * actualImageRef.current.naturalWidth;
+            const yOnNaturalImage = (clickYRelativeToImageOrigin / imageRect.height) * actualImageRef.current.naturalHeight;
+
+            // Convert to percentage of the natural image dimensions
+            const xPercent = (xOnNaturalImage / actualImageRef.current.naturalWidth) * 100;
+            const yPercent = (yOnNaturalImage / actualImageRef.current.naturalHeight) * 100;
+
+            // Clamp values between 0 and 100
+            const finalXPercent = Math.max(0, Math.min(100, xPercent));
+            const finalYPercent = Math.max(0, Math.min(100, yPercent));
+
+            onPlaceNewHotspot(finalXPercent, finalYPercent);
+            e.stopPropagation(); // Prevent other click handlers
+            return;
+          }
+        }
+        // Default behavior if not placing a hotspot
+        console.log('Debug [ImageEditCanvas]: Container click detected (default)', {
+          target: e.target,
+          currentTarget: e.currentTarget,
+          isEditing,
+          timestamp: Date.now()
+        });
+        onImageOrHotspotClick && onImageOrHotspotClick(e);
+      }}
+      onContextMenu={(e) => {
+        if (isPlacingHotspot && onCancelPlacement) {
+          e.preventDefault();
+          onCancelPlacement();
+        }
+        // Allow default context menu if not placing hotspot or if onCancelPlacement is not defined
+      }}
+    >
+      <div
+          className={`relative flex items-center justify-center ${isMobile ? 'min-w-full min-h-full' : 'min-w-full min-h-full'} ${
+            isDragModeActive ? 'drag-mode-active' : ''
+          }`}
+        style={{
+          // Cursor styling is now handled by the parent scrollableContainerRef
+          zIndex: Z_INDEX_IMAGE_BASE
+        }}
+          // For mobile, the click is handled by the parent div in InteractiveModule which then calls onImageOrHotspotClick.
+          // For desktop, the click is handled by the scrollableContainerRef above.
+          // If we need finer-grained click detection within this div (e.g. on the image itself vs. padding),
+          // this onClick could be used, ensuring it calls onImageOrHotspotClick appropriately.
+          // For now, the main click logic is on scrollableContainerRef for desktop.
+      >
+        {backgroundImage ? (
+          <div
+            ref={zoomedImageContainerRef}
+            className="relative"
+            style={{
+              transform: `scale(${editingZoom})`,
+              transformOrigin: 'center',
+              transition: 'transform 0.2s ease-out',
+              // zIndex for desktop, mobile canvas is simpler
+              zIndex: !isMobile && editingZoom > 1 ? Z_INDEX_IMAGE_TRANSFORMED : Z_INDEX_IMAGE_BASE,
+            }}
+          >
+            <img
+              ref={actualImageRef}
+              src={backgroundImage}
+              alt="Interactive module background"
+              className={isMobile ? "block max-w-full max-h-full object-contain" : "block max-w-none"}
+              style={!isMobile ? { // Desktop specific styles from original
+                width: scrollableContainerRef.current?.clientWidth || 'auto',
+                height: 'auto',
+              } : {}}
+              onLoad={onImageLoad}
+              draggable={false}
+            />
+
+            {/* Highlight overlay - ensure it's within the scaled container */}
+            {highlightedHotspotId && backgroundImage && activeHotspotDisplayIds.has(highlightedHotspotId) && (
+              <div
+                className="absolute inset-0 pointer-events-none"
+                style={getHighlightGradientStyle()}
+                aria-hidden="true"
+              />
+            )}
+
+            {/* Hotspots */}
+            {console.log('Debug [ImageEditCanvas]: Rendering hotspots', {
+              hotspotsCount: hotspotsWithPositions.length,
+              isEditing,
+              hotspotIds: hotspotsWithPositions.map(h => h.id),
+              timestamp: Date.now()
+            }) || hotspotsWithPositions.map(hotspot => (
+              <div
+                key={hotspot.id}
+                className="hotspot-viewer"
+                style={{
+                  touchAction: isMobile ? 'none' : 'auto', // Better mobile drag performance
+                  pointerEvents: 'auto', // Ensure pointer events are enabled
+                  position: 'relative', // Ensure proper positioning context
+                  zIndex: isEditing ? 1000 : 100 // Higher z-index in editing mode for better interaction
+                }}
+              >
+                <HotspotViewer
+                  hotspot={hotspot}
+                  pixelPosition={hotspot.pixelPosition}
+                  usePixelPositioning={true}
+                  imageElement={actualImageRef.current}
+                  isPulsing={pulsingHotspotId === hotspot.id && activeHotspotDisplayIds.has(hotspot.id)}
+                  isDimmedInEditMode={getIsHotspotDimmed(hotspot.id)}
+                  isEditing={isEditing}
+                  onFocusRequest={onFocusHotspot}
+                  onEditRequest={onEditHotspotRequest}
+                  onPositionChange={onHotspotPositionChange}
+                  onDragStateChange={onDragStateChange}
+                  isContinuouslyPulsing={false} // Assuming this is for viewer mode, not editor
+                  isMobile={isMobile}
+                  dragContainerRef={zoomedImageContainerRef} // Pass the ref here
+                />
+              </div>
+            ))}
+
+            {/* Preview Overlays - Only show when preview is active and in editing mode */}
+            {isEditing && previewOverlayEvent && onPreviewOverlayUpdate && (
+              <>
+                {/* Calculate container bounds for overlays using standardized bounds */}
+                {(() => {
+                  // Use standardized bounds if available, fallback to current method
+                  let containerBounds = null;
+                  let boundsSource = 'none';
+
+                  if (getImageBounds && imageNaturalDimensions) {
+                    // Calculate edit-mode bounds that match view-mode positioning
+                    const imgElement = actualImageRef.current;
+                    if (imgElement && imageNaturalDimensions) {
+                      const imgRect = imgElement.getBoundingClientRect();
+                      const imageAspect = imageNaturalDimensions.width / imageNaturalDimensions.height;
+                      const containerAspect = imgRect.width / imgRect.height;
+
+                      // Calculate content area using the same logic as view mode
+                      let contentWidth, contentHeight;
+
+                      // Edit mode typically uses 'contain' behavior
+                      if (containerAspect > imageAspect) {
+                        // Container is wider - image height fills, width is letterboxed
+                        contentHeight = imgRect.height;
+                        contentWidth = contentHeight * imageAspect;
+                      } else {
+                        // Container is taller - image width fills, height is letterboxed
+                        contentWidth = imgRect.width;
+                        contentHeight = contentWidth / imageAspect;
+                      }
+
+                      containerBounds = {
+                        width: contentWidth,
+                        height: contentHeight,
+                        left: 0,
+                        top: 0
+                      };
+                      boundsSource = 'edit-mode-calculated';
+                      console.log('📐 BOUNDS DEBUG: Using edit-mode calculated bounds', {
+                        containerBounds,
+                        imgRect,
+                        imageNaturalDimensions,
+                        imageAspect,
+                        containerAspect,
+                        imageFitMode,
+                        isEditing
+                      });
+                    }
+                  }
+
+                  // Fallback to original method if standardized bounds not available
+                  if (!containerBounds) {
+                    const imgElement = actualImageRef.current;
+                    if (!imgElement) return null;
+
+                    const imgRect = imgElement.getBoundingClientRect();
+                    containerBounds = {
+                      width: imgRect.width,
+                      height: imgRect.height,
+                      left: 0, // Relative to the image
+                      top: 0
+                    };
+                    boundsSource = 'fallback';
+                    console.log('📐 BOUNDS DEBUG: Using fallback bounds', {
+                      containerBounds,
+                      imgRect,
+                      isEditing
+                    });
+                  }
+
+                  // Render the appropriate overlay based on event type
+                  if (previewOverlayEvent.type === InteractionType.PAN_ZOOM ||
+                      previewOverlayEvent.type === InteractionType.PAN_ZOOM_TO_HOTSPOT) {
+                    return (
+                      <PanZoomPreviewOverlay
+                        event={previewOverlayEvent}
+                        onUpdate={onPreviewOverlayUpdate}
+                        containerBounds={containerBounds}
+                      />
+                    );
+                  }
+
+                  if (previewOverlayEvent.type === InteractionType.SPOTLIGHT ||
+                      previewOverlayEvent.type === InteractionType.HIGHLIGHT_HOTSPOT) {
+                    return (
+                      <SpotlightPreviewOverlay
+                        event={previewOverlayEvent}
+                        onUpdate={onPreviewOverlayUpdate}
+                        containerBounds={containerBounds}
+                      />
+                    );
+                  }
+
+                  if (previewOverlayEvent.type === InteractionType.SHOW_TEXT) {
+                    return (
+                      <TextPreviewOverlay
+                        event={previewOverlayEvent}
+                        onUpdate={onPreviewOverlayUpdate}
+                        containerBounds={containerBounds}
+                      />
+                    );
+                  }
+
+                  return null;
+                })()}
+              </>
+            )}
+          </div>
+        ) : (
+          onImageUpload && ( // Only show upload if handler is provided
+            <div className="w-full h-full flex items-center justify-center text-slate-400">
+              <div className="text-center">
+                <p className="text-lg mb-4">Upload an image to start editing</p>
+                <FileUpload onFileUpload={onImageUpload} />
+              </div>
+            </div>
+          )
+        )}
+
+      </div>
+      {isPlacingHotspot && (
+        <div
+          className="absolute inset-0 flex items-center justify-center pointer-events-none"
+          style={{ zIndex: 100 }} // Ensure it's above other elements but below potential modals
+        >
+          <div className="bg-black bg-opacity-50 text-white p-3 rounded-md shadow-lg">
+            Click to place hotspot. Right-click to cancel.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+});
         // If currently placing a hotspot and the click is on the canvas background (not a hotspot itself)
         if (isPlacingHotspot && onPlaceNewHotspot && actualImageRef.current) {
           const target = e.target as HTMLElement;

--- a/src/client/components/InteractiveModule.tsx
+++ b/src/client/components/InteractiveModule.tsx
@@ -1738,6 +1738,13 @@ const InteractiveModule: React.FC<InteractiveModuleProps> = ({
     }
   }, [isPlacingHotspot, setIsPlacingHotspot]);
 
+  const handleCancelHotspotPlacement = useCallback(() => {
+    if (isPlacingHotspot) {
+      setIsPlacingHotspot(false);
+      console.log("Hotspot placement cancelled via right-click or other direct cancel action.");
+    }
+  }, [isPlacingHotspot, setIsPlacingHotspot]);
+
   const handlePlaceNewHotspot = useCallback((x: number, y: number) => {
     const currentScheme = COLOR_SCHEMES.find(s => s.name === colorScheme) || COLOR_SCHEMES[0];
     const defaultColor = currentScheme.colors[hotspots.length % currentScheme.colors.length];
@@ -2355,6 +2362,8 @@ const InteractiveModule: React.FC<InteractiveModuleProps> = ({
                     imageFitMode={imageFitMode}
                     previewOverlayEvent={previewOverlayEvent}
                     onPreviewOverlayUpdate={handlePreviewOverlayUpdate}
+                 isPlacingHotspot={isPlacingHotspot} // Pass down isPlacingHotspot
+                 onCancelPlacement={handleCancelHotspotPlacement} // Pass down the cancel handler
                   />
                 </div>
 


### PR DESCRIPTION
- Added an overlay message ("Click to place hotspot. Right-click to cancel.") on the image canvas when in hotspot placement mode.
- Ensured the mouse cursor changes to 'crosshair' during placement mode.
- Implemented right-click on the image canvas as a method to cancel hotspot placement mode.
- Updated the 'Add Hotspot' button titles in the EditorToolbar to reflect the new cancellation options.
- Wired the necessary callbacks through InteractiveModule to ImageEditCanvas to support these features.