### PR TITLE
feat: Add 'Skip to Main Content' link for improved accessibility

### DIFF
--- a/src/client/components/InteractiveModule.tsx
+++ b/src/client/components/InteractiveModule.tsx
@@ -2144,7 +2144,13 @@ const InteractiveModule: React.FC<InteractiveModuleProps> = ({
 
 
   return (
-    <div className={`text-slate-200 ${isEditing ? 'fixed inset-0 z-50 bg-slate-900' : 'fixed inset-0 z-50 bg-slate-900'}`}>
+    <div
+      id="main-content"
+      tabIndex={-1}
+      className={`text-slate-200 ${isEditing ? 'fixed inset-0 z-50 bg-slate-900' : 'fixed inset-0 z-50 bg-slate-900'}`}
+      // Add outline-none to prevent default focus ring if not desired, or style it appropriately
+      // style={{ outline: 'none' }}
+    >
       {isEditing ? (
         isMobile ? (
           <MobileEditorLayout

--- a/src/client/components/SharedModuleViewer.tsx
+++ b/src/client/components/SharedModuleViewer.tsx
@@ -117,8 +117,11 @@ const SharedModuleViewer: React.FC<SharedModuleViewerProps> = () => {
     <div className={`min-h-screen ${
       theme === 'light' ? 'bg-gray-100' : 'bg-slate-900'
     } ${isEmbedMode ? '' : 'relative'}`}>
+      <a href="#main-content" className="skip-to-main-content-link">
+        Skip to Main Content
+      </a>
       {/* Main Module Content */}
-      <div className={`${isEmbedMode ? 'h-screen' : 'min-h-screen'}`}>
+      <div id="main-content-wrapper" className={`${isEmbedMode ? 'h-screen' : 'min-h-screen'}`}>
         <InteractiveModule
           key={`shared-${project.id}`}
           initialData={project.interactiveData}

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -201,6 +201,34 @@
   }
 }
 
+/* Skip to Main Content Link Styles */
+.skip-to-main-content-link {
+  position: absolute;
+  left: -9999px; /* Send off-screen */
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  z-index: -9999; /* Ensure it's not interactive when hidden */
+  background-color: #3b82f6; /* Tailwind blue-500 */
+  color: white;
+  padding: 0.75rem 1rem; /* p-3 p-4 */
+  border-radius: 0.375rem; /* rounded-md */
+  text-decoration: none;
+  font-weight: 600; /* font-semibold */
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06); /* shadow-md */
+}
+
+.skip-to-main-content-link:focus,
+.skip-to-main-content-link:active {
+  left: 1rem; /* Bring it on-screen */
+  top: 1rem;
+  width: auto;
+  height: auto;
+  overflow: visible;
+  z-index: 99999; /* Ensure it's on top when focused */
+}
+
 /* Loading states */
 .loading-spinner {
   animation: spin 1s linear infinite;


### PR DESCRIPTION
Implemented a 'Skip to Main Content' link to enhance keyboard navigation and accessibility for users.

Key changes:
- Added a visually hidden link in `SharedModuleViewer.tsx` that becomes visible on focus, allowing users to bypass navigation and jump directly to the main interactive module.
- Defined CSS styles in `src/client/index.css` for the link's hidden and focused states.
- Made the main content area in `InteractiveModule.tsx` focusable by adding `id="main-content"` and `tabIndex="-1"` to its container.

This change improves the user experience for keyboard-only users and screen reader users by providing a standard accessibility pattern.