### PR TITLE
Fix: Implement distinct media event types for hotspots

### DIFF
--- a/src/client/components/EditableEventCard.tsx
+++ b/src/client/components/EditableEventCard.tsx
@@ -181,22 +181,156 @@ const EditableEventCard: React.FC<EditableEventCardProps> = ({
         );
 
       case InteractionType.SHOW_IMAGE_MODAL:
+        return (
+          <div className="space-y-2 mt-2">
+            <input
+              type="text"
+              value={event.imageUrl || ''}
+              onChange={(e) => onUpdate({ ...event, imageUrl: e.target.value })}
+              className="w-full bg-gray-800 text-white p-1 rounded"
+              placeholder="Enter Image URL"
+            />
+            <input
+              type="text"
+              value={event.caption || ''}
+              onChange={(e) => onUpdate({ ...event, caption: e.target.value })}
+              className="w-full bg-gray-800 text-white p-1 rounded"
+              placeholder="Optional: Caption"
+            />
+          </div>
+        );
       case InteractionType.SHOW_VIDEO:
+        return (
+          <div className="space-y-2 mt-2">
+            <input
+              type="text"
+              value={event.videoUrl || ''}
+              onChange={(e) => onUpdate({ ...event, videoUrl: e.target.value })}
+              className="w-full bg-gray-800 text-white p-1 rounded"
+              placeholder="Enter Video URL (e.g., .mp4)"
+            />
+            <input
+              type="text"
+              value={event.poster || ''}
+              onChange={(e) => onUpdate({ ...event, poster: e.target.value })}
+              className="w-full bg-gray-800 text-white p-1 rounded"
+              placeholder="Optional: Poster Image URL"
+            />
+            <div className="flex items-center space-x-4">
+              <label className="flex items-center space-x-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={!!event.autoplay} // Ensure boolean value
+                  onChange={(e) => onUpdate({ ...event, autoplay: e.target.checked })}
+                  className="form-checkbox h-4 w-4 text-blue-600 bg-gray-800 border-gray-700 rounded focus:ring-blue-500"
+                />
+                <span className="text-sm">Autoplay</span>
+              </label>
+              <label className="flex items-center space-x-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={!!event.loop} // Ensure boolean value
+                  onChange={(e) => onUpdate({ ...event, loop: e.target.checked })}
+                  className="form-checkbox h-4 w-4 text-blue-600 bg-gray-800 border-gray-700 rounded focus:ring-blue-500"
+                />
+                <span className="text-sm">Loop</span>
+              </label>
+            </div>
+          </div>
+        );
+      case InteractionType.SHOW_AUDIO_MODAL:
+        return (
+          <div className="space-y-2 mt-2">
+            <input
+              type="text"
+              value={event.audioUrl || ''}
+              onChange={(e) => onUpdate({ ...event, audioUrl: e.target.value })}
+              className="w-full bg-gray-800 text-white p-1 rounded"
+              placeholder="Enter Audio URL (e.g., .mp3)"
+            />
+            <input
+              type="text"
+              value={event.textContent || ''} // Using textContent for Audio Title as per InteractiveModule
+              onChange={(e) => onUpdate({ ...event, textContent: e.target.value })}
+              className="w-full bg-gray-800 text-white p-1 rounded"
+              placeholder="Optional: Track Title"
+            />
+            <input
+              type="text"
+              value={event.artist || ''}
+              onChange={(e) => onUpdate({ ...event, artist: e.target.value })}
+              className="w-full bg-gray-800 text-white p-1 rounded"
+              placeholder="Optional: Artist Name"
+            />
+            <div className="flex items-center space-x-4">
+              <label className="flex items-center space-x-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={!!event.autoplay} // Ensure boolean value
+                  onChange={(e) => onUpdate({ ...event, autoplay: e.target.checked })}
+                  className="form-checkbox h-4 w-4 text-blue-600 bg-gray-800 border-gray-700 rounded focus:ring-blue-500"
+                />
+                <span className="text-sm">Autoplay</span>
+              </label>
+              <label className="flex items-center space-x-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={!!event.loop} // Ensure boolean value
+                  onChange={(e) => onUpdate({ ...event, loop: e.target.checked })}
+                  className="form-checkbox h-4 w-4 text-blue-600 bg-gray-800 border-gray-700 rounded focus:ring-blue-500"
+                />
+                <span className="text-sm">Loop</span>
+              </label>
+            </div>
+          </div>
+        );
       case InteractionType.SHOW_YOUTUBE:
         return (
-          <input
-            type="text"
-            value={event.url || event.mediaUrl || event.imageUrl || event.videoUrl || ''}
-            onChange={(e) => onUpdate({ 
-              ...event, 
-              url: e.target.value,
-              mediaUrl: e.target.value,
-              imageUrl: e.target.value,
-              videoUrl: e.target.value
-            })}
-            className="w-full bg-gray-800 text-white p-1 rounded"
-            placeholder="Enter media URL"
-          />
+          <div className="space-y-2 mt-2">
+            <input
+              type="text"
+              value={event.youtubeVideoId || ''}
+              onChange={(e) => onUpdate({ ...event, youtubeVideoId: e.target.value })}
+              className="w-full bg-gray-800 text-white p-1 rounded"
+              placeholder="Enter YouTube Video ID"
+            />
+            <div className="grid grid-cols-2 gap-2">
+              <input
+                type="number"
+                value={event.youtubeStartTime === undefined ? '' : event.youtubeStartTime} // Handle undefined for placeholder
+                onChange={(e) => onUpdate({ ...event, youtubeStartTime: e.target.value ? parseInt(e.target.value) : undefined })}
+                className="w-full bg-gray-800 text-white p-1 rounded"
+                placeholder="Start (secs)"
+              />
+              <input
+                type="number"
+                value={event.youtubeEndTime === undefined ? '' : event.youtubeEndTime} // Handle undefined for placeholder
+                onChange={(e) => onUpdate({ ...event, youtubeEndTime: e.target.value ? parseInt(e.target.value) : undefined })}
+                className="w-full bg-gray-800 text-white p-1 rounded"
+                placeholder="End (secs)"
+              />
+            </div>
+            <div className="flex items-center space-x-4">
+              <label className="flex items-center space-x-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={!!event.autoplay} // Ensure boolean value
+                  onChange={(e) => onUpdate({ ...event, autoplay: e.target.checked })}
+                  className="form-checkbox h-4 w-4 text-blue-600 bg-gray-800 border-gray-700 rounded focus:ring-blue-500"
+                />
+                <span className="text-sm">Autoplay</span>
+              </label>
+              <label className="flex items-center space-x-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={!!event.loop} // Ensure boolean value
+                  onChange={(e) => onUpdate({ ...event, loop: e.target.checked })}
+                  className="form-checkbox h-4 w-4 text-blue-600 bg-gray-800 border-gray-700 rounded focus:ring-blue-500"
+                />
+                <span className="text-sm">Loop</span>
+              </label>
+            </div>
+          </div>
         );
 
       case InteractionType.QUIZ:

--- a/src/client/components/HotspotEditorModal.tsx
+++ b/src/client/components/HotspotEditorModal.tsx
@@ -31,11 +31,14 @@ interface EnhancedHotspotEditorModalProps {
 // Event Type Selector Component
 const EventTypeSelector: React.FC<{ onSelectEventType: (type: InteractionType) => void }> = ({ onSelectEventType }) => {
   const eventTypes: { type: InteractionType; label: string }[] = [
-    { type: InteractionType.SPOTLIGHT, label: 'spotlight' },
-    { type: InteractionType.PAN_ZOOM, label: 'pan-zoom' },
-    { type: InteractionType.SHOW_TEXT, label: 'text' },
-    { type: InteractionType.SHOW_IMAGE_MODAL, label: 'media' },
-    { type: InteractionType.QUIZ, label: 'question' },
+    { type: InteractionType.SPOTLIGHT, label: 'Spotlight' },
+    { type: InteractionType.PAN_ZOOM, label: 'Pan & Zoom' },
+    { type: InteractionType.SHOW_TEXT, label: 'Text Display' },
+    { type: InteractionType.SHOW_IMAGE_MODAL, label: 'Image Modal' },
+    { type: InteractionType.SHOW_VIDEO, label: 'Video Modal' },
+    { type: InteractionType.SHOW_AUDIO_MODAL, label: 'Audio Modal' },
+    { type: InteractionType.SHOW_YOUTUBE, label: 'YouTube Modal' },
+    { type: InteractionType.QUIZ, label: 'Quiz Question' },
   ];
 
   return (
@@ -44,10 +47,11 @@ const EventTypeSelector: React.FC<{ onSelectEventType: (type: InteractionType) =
         <button
           key={type}
           onClick={() => onSelectEventType(type)}
-          className="px-2 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs flex flex-col items-center gap-1"
+          className="px-2 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 text-xs flex flex-col items-center gap-1 justify-center min-h-[50px]" // Added justify-center and min-h
         >
-          <span className="text-lg">+</span>
-          <span>{label}</span>
+          {/* Using a generic icon for now, could be specific later */}
+          <PlusIcon className="w-4 h-4 mb-0.5" />
+          <span className="text-center">{label}</span>
         </button>
       ))}
     </div>
@@ -181,12 +185,33 @@ const EnhancedHotspotEditorModal: React.FC<EnhancedHotspotEditorModalProps> = ({
         textWidth: 200,
         textHeight: 60
       }),
-      ...(type === InteractionType.SHOW_IMAGE_MODAL && { 
-        url: '', 
-        mediaUrl: '',
-        mediaType: 'image'
+      ...(type === InteractionType.SHOW_IMAGE_MODAL && {
+        imageUrl: '', // Correct field for SHOW_IMAGE_MODAL
+        mediaType: 'image', // Keep for clarity, though InteractiveModule uses the main type
+        name: 'New Image Modal',
       }),
-      ...(type === InteractionType.QUIZ && { 
+      ...(type === InteractionType.SHOW_VIDEO && {
+        videoUrl: '', // Correct field for SHOW_VIDEO
+        mediaType: 'video',
+        name: 'New Video Modal',
+        autoplay: false,
+        loop: false,
+      }),
+      ...(type === InteractionType.SHOW_AUDIO_MODAL && {
+        audioUrl: '', // Correct field for SHOW_AUDIO_MODAL
+        mediaType: 'audio',
+        name: 'New Audio Modal',
+        autoplay: false,
+        loop: false,
+      }),
+      ...(type === InteractionType.SHOW_YOUTUBE && {
+        youtubeVideoId: '', // Correct field for SHOW_YOUTUBE
+        mediaType: 'youtube',
+        name: 'New YouTube Modal',
+        autoplay: false,
+        loop: false,
+      }),
+      ...(type === InteractionType.QUIZ && {
         question: 'Enter question',
         quizQuestion: 'Enter question',
         targetHotspotId: '' 


### PR DESCRIPTION
This change addresses the issue where the generic 'media' event type for hotspots only supported images and did so inconsistently.

Modifications:

1.  **EventTypeSelector (`HotspotEditorModal.tsx`)**:
    *   Replaced the single 'media' option with four distinct options: 'Image Modal', 'Video Modal', 'Audio Modal', and 'YouTube Modal'.
    *   These map to `InteractionType.SHOW_IMAGE_MODAL`, `InteractionType.SHOW_VIDEO`, `InteractionType.SHOW_AUDIO_MODAL`, and `InteractionType.SHOW_YOUTUBE` respectively.

2.  **HotspotEditorModal.tsx (`handleAddEvent`)**:
    *   Updated to initialize `TimelineEventData` with the correct `InteractionType` based on the selected media type.
    *   Ensures the correct specific URL property (e.g., `imageUrl`, `videoUrl`, `audioUrl`, `youtubeVideoId`) is initialized.
    *   Sets appropriate default values for media-specific options like `autoplay`, `loop`, and default names.

3.  **EditableEventCard.tsx (`renderSettings`)**:
    *   Modified to render specific input fields tailored to each media type:
        *   **Image Modal**: Inputs for Image URL and Caption.
        *   **Video Modal**: Inputs for Video URL, Poster URL, Autoplay, and Loop.
        *   **Audio Modal**: Inputs for Audio URL, Track Title, Artist, Autoplay, and Loop.
        *   **YouTube Modal**: Inputs for YouTube Video ID, Start Time, End Time, Autoplay, and Loop.
    *   Ensures that updates correctly modify the respective event properties.

This allows users to properly configure and use various media types (image, video, audio, YouTube) as events associated with hotspots.