### PR TITLE
feat: Implement video backgrounds for modules

### DIFF
--- a/src/client/components/EditorToolbar.tsx
+++ b/src/client/components/EditorToolbar.tsx
@@ -43,6 +43,14 @@ interface EditorToolbarProps {
   
   // Share functionality
   project?: Project; // Optional project data for sharing
+
+  // Background settings props to pass to EnhancedModalEditorToolbar
+  backgroundImage?: string;
+  backgroundType?: 'image' | 'video';
+  backgroundVideoType?: 'youtube' | 'mp4';
+  onBackgroundImageChange: (url: string) => void;
+  onBackgroundTypeChange: (type: 'image' | 'video') => void;
+  onBackgroundVideoTypeChange: (type: 'youtube' | 'mp4') => void;
 }
 
 const EditorToolbar: React.FC<EditorToolbarProps> = (props) => {
@@ -173,6 +181,13 @@ const EditorToolbar: React.FC<EditorToolbarProps> = (props) => {
           onClose={() => setShowMobileMenu(false)}
           {...props}
           isMobile={true} // Pass isMobile to the modal as well
+          // Pass background props
+          backgroundImage={props.backgroundImage}
+          backgroundType={props.backgroundType}
+          backgroundVideoType={props.backgroundVideoType}
+          onBackgroundImageChange={props.onBackgroundImageChange}
+          onBackgroundTypeChange={props.onBackgroundTypeChange}
+          onBackgroundVideoTypeChange={props.onBackgroundVideoTypeChange}
         />
       </>
     );
@@ -313,6 +328,13 @@ const EditorToolbar: React.FC<EditorToolbarProps> = (props) => {
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         {...props}
+        // Pass background props
+        backgroundImage={props.backgroundImage}
+        backgroundType={props.backgroundType}
+        backgroundVideoType={props.backgroundVideoType}
+        onBackgroundImageChange={props.onBackgroundImageChange}
+        onBackgroundTypeChange={props.onBackgroundTypeChange}
+        onBackgroundVideoTypeChange={props.onBackgroundVideoTypeChange}
       />
 
       {/* Share Modal */}

--- a/src/shared/InteractionPresets.ts
+++ b/src/shared/InteractionPresets.ts
@@ -104,6 +104,13 @@ export const interactionPresets: Record<InteractionType, InteractionPreset> = {
     settings: ['audioUrl', 'volume'],
     description: 'Play audio narration'
   },
+  [InteractionType.PLAY_VIDEO]: { // Added preset for PLAY_VIDEO
+    icon: '🎞️', // Placeholder icon
+    name: 'Play Video Inline', // Placeholder name
+    color: 'bg-orange-500', // Placeholder color
+    settings: ['videoUrl', 'autoplay', 'loop'], // Placeholder settings
+    description: 'Play video directly in content (not modal)' // Placeholder description
+  },
   
   // Media modal interaction types
   [InteractionType.SHOW_VIDEO]: {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -193,10 +193,12 @@ export interface HotspotEventGroup {
 }
 
 export interface InteractiveModuleState {
-  backgroundImage?: string; // Base64 string of the image when loaded, or undefined
+  backgroundImage?: string; // URL for image or video
+  backgroundType?: 'image' | 'video'; // Defaults to 'image' if undefined
+  backgroundVideoType?: 'youtube' | 'mp4'; // Relevant if backgroundType is 'video'
   hotspots?: HotspotData[]; // Made optional for deferred loading
   timelineEvents?: TimelineEventData[]; // Made optional for deferred loading
-  imageFitMode?: 'cover' | 'contain' | 'fill'; // Image display mode
+  imageFitMode?: 'cover' | 'contain' | 'fill'; // Keep for images and potentially for video letter/pillarboxing
 }
 
 // Stored in simulated Drive (module_data.json within project folder)


### PR DESCRIPTION
Adds support for using YouTube or MP4 videos as module backgrounds.

Key changes:
- Updated `InteractiveModuleState` to include `backgroundType` and `backgroundVideoType`.
- Modified `EnhancedModalEditorToolbar` and `EditorToolbar` to provide UI for selecting background type (image/video) and inputting the URL.
- Implemented conditional rendering in `InteractiveModule` to display either an image, a YouTube video (using `YouTubePlayer`), or an MP4 video (using `VideoPlayer`) as the background.
- Video backgrounds are configured to autoplay, loop, and be muted, with controls hidden.
- Added `extractYouTubeVideoId` helper function.
- Ensured all Vitest tests pass by adding a missing preset for `InteractionType.PLAY_VIDEO` in `InteractionPresets.ts`.