### PR TITLE
Fix: Use scrollableContainerRef for image bounds calculation

### DIFF
--- a/src/client/components/InteractiveModule.tsx
+++ b/src/client/components/InteractiveModule.tsx
@@ -422,7 +422,7 @@ const InteractiveModule: React.FC<InteractiveModuleProps> = ({
       return null;
     }
 
-    const containerRect = scrollableContainerRef.current.getBoundingClientRect();
+    const containerRect = (isEditing ? scrollableContainerRef.current : imageContainerRef.current).getBoundingClientRect();
 
     if (isEditing && actualImageRef.current) {
       // Editor mode: Extract bounds from actual img element but normalize to match viewer calculations

--- a/src/client/components/InteractiveModule.tsx
+++ b/src/client/components/InteractiveModule.tsx
@@ -422,7 +422,7 @@ const InteractiveModule: React.FC<InteractiveModuleProps> = ({
       return null;
     }
 
-    const containerRect = imageContainerRef.current.getBoundingClientRect();
+    const containerRect = scrollableContainerRef.current.getBoundingClientRect();
 
     if (isEditing && actualImageRef.current) {
       // Editor mode: Extract bounds from actual img element but normalize to match viewer calculations


### PR DESCRIPTION
This change modifies the getImageBounds function to use scrollableContainerRef instead of imageContainerRef when calculating the containerRect. This ensures accurate bounds calculation in all cases, including mobile mode with safe area insets and flex layout spacing.