### PR TITLE
Fix: Render image backgrounds using <img> tag in viewer

### DIFF
--- a/src/client/components/InteractiveModule.tsx
+++ b/src/client/components/InteractiveModule.tsx
@@ -2884,12 +2884,27 @@ const InteractiveModule: React.FC<InteractiveModuleProps> = ({
                         })(),
                         maxHeight: isMobile ? '100%' : '800px',
                         zIndex: imageTransform.scale > 1 ? Z_INDEX.IMAGE_TRANSFORMED : Z_INDEX.IMAGE_BASE,
-                        // Ensure the container itself doesn't have a background image if a video is playing
-                        backgroundImage: (backgroundType === 'video' && backgroundImage) ? 'none' : (backgroundImage ? `url(${backgroundImage})` : 'none'),
+                        // Ensure the container itself doesn't have a background image if child elements handle it
+                        backgroundImage: 'none', // Always none, child elements will render image/video
                       }}
                       aria-hidden="true"
                     >
                       {/* Conditional Background Content */}
+                      {/* Image Rendering for Viewer Mode */}
+                      {backgroundType === 'image' && backgroundImage && !isEditing && (
+                        <img
+                          src={backgroundImage}
+                          alt={projectName || 'Module background'} // Use projectName for more context
+                          style={{
+                            width: '100%',
+                            height: '100%',
+                            objectFit: imageFitMode,
+                            objectPosition: 'center',
+                          }}
+                        />
+                      )}
+
+                      {/* Video Rendering */}
                       {(backgroundType === 'video' && backgroundImage) ? (
                         backgroundVideoType === 'youtube' ? (
                           <YouTubePlayer

--- a/src/client/components/InteractiveModule.tsx
+++ b/src/client/components/InteractiveModule.tsx
@@ -2894,7 +2894,7 @@ const InteractiveModule: React.FC<InteractiveModuleProps> = ({
                       {backgroundType === 'image' && backgroundImage && !isEditing && (
                         <img
                           src={backgroundImage}
-                          alt={projectName || 'Module background'} // Use projectName for more context
+                          alt=""
                           style={{
                             width: '100%',
                             height: '100%',


### PR DESCRIPTION
Previously, image backgrounds in the viewer mode were rendered using the CSS `background-image` property on the `scaledImageDivRef` div. This could lead to issues where the image wouldn't display, and if the hidden image loader also failed to get dimensions, hotspots would be misplaced.

This commit changes the rendering strategy for image backgrounds in viewer mode (`!isEditing` and `backgroundType === 'image'`). An explicit `<img>` tag is now rendered inside `scaledImageDivRef` to display the image. This `<img>` tag uses `object-fit: imageFitMode` to respect the chosen fitting behavior.

The `scaledImageDivRef` div's own `backgroundImage` CSS property is now always set to 'none', as child elements (`<img>` for images, or video players for videos) are responsible for rendering the background content.

The existing hidden `<img>` tag used for obtaining `imageNaturalDimensions` (crucial for hotspot calculations) remains unchanged.

This approach aims to make image rendering in the viewer more consistent with the editor (which uses `ImageEditCanvas` with an `<img>` tag) and potentially more robust.