### PR TITLE
Fix: Prevent scroll bleed in MediaModal on mobile

### DIFF
--- a/src/client/components/MediaModal.tsx
+++ b/src/client/components/MediaModal.tsx
@@ -72,7 +72,7 @@ const MediaModal: React.FC<MediaModalProps> = ({
             <XMarkIcon className="w-6 h-6" />
           </button>
         </header>
-        <div className="flex-grow overflow-hidden flex flex-col">
+        <div className="flex-grow overflow-hidden flex flex-col touch-none">
           {children}
         </div>
       </div>


### PR DESCRIPTION
Applied `touch-action: none` to the content wrapper within MediaModal. This aims to prevent touch events from scrolling the underlying page when you are interacting with content like ImageViewer, which handles its own pan/zoom gestures.

The ImageViewer component already uses `touch-action: none` and `event.preventDefault()` for its gesture handling. This change adds an additional layer of protection in the modal structure itself to ensure that touches intended for modal content manipulation do not inadvertently trigger browser default actions (like scrolling the page behind the modal) on mobile devices.