### PR TITLE
Fix: Allow vertical dragging of hotspots in editor

### DIFF
--- a/src/client/components/ImageEditCanvas.tsx
+++ b/src/client/components/ImageEditCanvas.tsx
@@ -254,7 +254,7 @@ const ImageEditCanvas: React.FC<ImageEditCanvasProps> = React.memo(({
                 style={{
                   touchAction: isMobile ? 'none' : 'auto', // Better mobile drag performance
                   pointerEvents: 'auto', // Ensure pointer events are enabled
-                  position: 'relative', // Ensure proper positioning context
+                  // position: 'relative', // Removed to allow absolute positioning relative to zoomedImageContainerRef
                   zIndex: isEditing ? 1000 : 100 // Higher z-index in editing mode for better interaction
                 }}
               >


### PR DESCRIPTION
Removed `position: relative` from the wrapper div around HotspotViewer in ImageEditCanvas.tsx. This ensures that absolutely positioned HotspotViewer components are positioned relative to the `zoomedImageContainerRef`, allowing them to be dragged vertically across the entire image area.

This addresses an issue where hotspots appeared stuck along a single horizontal plane at the bottom of the image, unable to be dragged vertically.