### PR TITLE
feat: Ensure all hotspot and event data is saved to Firestore

### DIFF
--- a/src/lib/dataSanitizer.ts
+++ b/src/lib/dataSanitizer.ts
@@ -23,43 +23,107 @@ export class DataSanitizer {
   }
 
   /**
-   * Sanitize timeline event data to remove undefined values
+   * Sanitize timeline event data to remove undefined values and ensure defaults
    * @param event - Timeline event to sanitize
-   * @returns Sanitized timeline event with undefined fields removed
+   * @returns Sanitized timeline event with all fields present
    */
-  static sanitizeTimelineEvent(event: TimelineEventData): Partial<TimelineEventData> {
-    const sanitized = this.removeUndefinedFields(event);
-    
-    // Validate that required fields exist to prevent Firebase errors
+  static sanitizeTimelineEvent(event: TimelineEventData): TimelineEventData {
+    const sanitized = this.removeUndefinedFields(event) as Partial<TimelineEventData>;
+
     if (!sanitized.id || sanitized.step === undefined || !sanitized.type) {
       throw new Error(`TimelineEvent is missing required fields: ${JSON.stringify(event)}`);
     }
-    
-    // Return sanitized object with validated required fields
+
+    // Return sanitized object with all fields present, providing defaults for optional fields
     return {
-      ...sanitized,
-      name: sanitized.name || ''
+      id: sanitized.id,
+      step: sanitized.step,
+      name: sanitized.name || '',
+      type: sanitized.type,
+      targetId: sanitized.targetId,
+      message: sanitized.message,
+      duration: sanitized.duration,
+      zoomFactor: sanitized.zoomFactor,
+      highlightRadius: sanitized.highlightRadius,
+      highlightShape: sanitized.highlightShape,
+      dimPercentage: sanitized.dimPercentage,
+      spotlightX: sanitized.spotlightX,
+      spotlightY: sanitized.spotlightY,
+      spotlightWidth: sanitized.spotlightWidth,
+      spotlightHeight: sanitized.spotlightHeight,
+      textContent: sanitized.textContent,
+      textPosition: sanitized.textPosition,
+      textX: sanitized.textX,
+      textY: sanitized.textY,
+      textWidth: sanitized.textWidth,
+      textHeight: sanitized.textHeight,
+      quizQuestion: sanitized.quizQuestion,
+      quizOptions: sanitized.quizOptions,
+      quizCorrectAnswer: sanitized.quizCorrectAnswer,
+      quizExplanation: sanitized.quizExplanation,
+      quizShuffleOptions: sanitized.quizShuffleOptions,
+      mediaType: sanitized.mediaType,
+      mediaUrl: sanitized.mediaUrl,
+      imageUrl: sanitized.imageUrl,
+      caption: sanitized.caption,
+      zoomLevel: sanitized.zoomLevel,
+      smooth: sanitized.smooth,
+      radius: sanitized.radius,
+      intensity: sanitized.intensity,
+      audioUrl: sanitized.audioUrl,
+      volume: sanitized.volume,
+      videoUrl: sanitized.videoUrl,
+      youtubeVideoId: sanitized.youtubeVideoId,
+      youtubeStartTime: sanitized.youtubeStartTime,
+      youtubeEndTime: sanitized.youtubeEndTime,
+      autoplay: sanitized.autoplay,
+      loop: sanitized.loop,
+      poster: sanitized.poster,
+      artist: sanitized.artist,
+      shape: sanitized.shape,
+      opacity: sanitized.opacity,
+      position: sanitized.position,
+      size: sanitized.size,
+      targetX: sanitized.targetX,
+      targetY: sanitized.targetY,
+      zoom: sanitized.zoom,
+      content: sanitized.content,
+      modalPosition: sanitized.modalPosition,
+      modalSize: sanitized.modalSize,
+      url: sanitized.url,
+      targetHotspotId: sanitized.targetHotspotId,
+      question: sanitized.question,
+      options: sanitized.options,
+      correctAnswer: sanitized.correctAnswer,
+      positioningVersion: sanitized.positioningVersion,
+      constraintsApplied: sanitized.constraintsApplied,
     };
   }
 
   /**
-   * Sanitize hotspot data to remove undefined values
+   * Sanitize hotspot data to remove undefined values and ensure defaults
    * @param hotspot - Hotspot to sanitize
-   * @returns Sanitized hotspot with undefined fields removed
+   * @returns Sanitized hotspot with all fields present
    */
-  static sanitizeHotspot(hotspot: HotspotData): Partial<HotspotData> {
-    const sanitized = this.removeUndefinedFields(hotspot);
-    
-    // Validate that required fields exist to prevent Firebase errors
+  static sanitizeHotspot(hotspot: HotspotData): HotspotData {
+    const sanitized = this.removeUndefinedFields(hotspot) as Partial<HotspotData>;
+
     if (!sanitized.id || sanitized.x === undefined || sanitized.y === undefined) {
       throw new Error(`Hotspot is missing required fields: ${JSON.stringify(hotspot)}`);
     }
-    
-    // Return sanitized object with validated required fields
+
+    // Return sanitized object with all fields present, providing defaults for optional fields
     return {
-      ...sanitized,
+      id: sanitized.id,
+      x: sanitized.x,
+      y: sanitized.y,
       title: sanitized.title || '',
-      description: sanitized.description || ''
+      description: sanitized.description || '',
+      color: sanitized.color,
+      backgroundColor: sanitized.backgroundColor,
+      size: sanitized.size || 'medium',
+      link: sanitized.link,
+      displayHotspotInEvent: sanitized.displayHotspotInEvent || false,
     };
   }
 

--- a/src/lib/dataSanitizer.ts
+++ b/src/lib/dataSanitizer.ts
@@ -23,107 +23,57 @@ export class DataSanitizer {
   }
 
   /**
-   * Sanitize timeline event data to remove undefined values and ensure defaults
+   * Sanitize timeline event data to remove undefined values
    * @param event - Timeline event to sanitize
-   * @returns Sanitized timeline event with all fields present
+   * @returns Sanitized timeline event with undefined fields removed
    */
-  static sanitizeTimelineEvent(event: Partial<TimelineEventData>): TimelineEventData {
-    const sanitized = this.removeUndefinedFields(event) as Partial<TimelineEventData>;
+  static sanitizeTimelineEvent(event: Partial<TimelineEventData>): Partial<TimelineEventData> {
+    const sanitized = this.removeUndefinedFields(event);
 
+    // Validate that required fields exist to prevent Firebase errors
     if (!sanitized.id || sanitized.step === undefined || !sanitized.type) {
       throw new Error(`TimelineEvent is missing required fields: ${JSON.stringify(event)}`);
     }
 
-    // Return sanitized object with all fields present, providing defaults for optional fields
+    const defaults = {
+      name: '',
+      zoomFactor: 2,
+      highlightRadius: 60,
+      highlightShape: 'circle' as const,
+      dimPercentage: 70,
+    }
+
+    // Return sanitized object with validated required fields
     return {
-      id: sanitized.id,
-      step: sanitized.step,
-      name: sanitized.name || '',
-      type: sanitized.type,
-      targetId: sanitized.targetId,
-      message: sanitized.message,
-      duration: sanitized.duration,
-      zoomFactor: sanitized.zoomFactor ?? 2,
-      highlightRadius: sanitized.highlightRadius ?? 60,
-      highlightShape: sanitized.highlightShape ?? 'circle',
-      dimPercentage: sanitized.dimPercentage ?? 70,
-      spotlightX: sanitized.spotlightX,
-      spotlightY: sanitized.spotlightY,
-      spotlightWidth: sanitized.spotlightWidth,
-      spotlightHeight: sanitized.spotlightHeight,
-      textContent: sanitized.textContent,
-      textPosition: sanitized.textPosition,
-      textX: sanitized.textX,
-      textY: sanitized.textY,
-      textWidth: sanitized.textWidth,
-      textHeight: sanitized.textHeight,
-      quizQuestion: sanitized.quizQuestion,
-      quizOptions: sanitized.quizOptions,
-      quizCorrectAnswer: sanitized.quizCorrectAnswer,
-      quizExplanation: sanitized.quizExplanation,
-      quizShuffleOptions: sanitized.quizShuffleOptions,
-      mediaType: sanitized.mediaType,
-      mediaUrl: sanitized.mediaUrl,
-      imageUrl: sanitized.imageUrl,
-      caption: sanitized.caption,
-      zoomLevel: sanitized.zoomLevel,
-      smooth: sanitized.smooth,
-      radius: sanitized.radius,
-      intensity: sanitized.intensity,
-      audioUrl: sanitized.audioUrl,
-      volume: sanitized.volume,
-      videoUrl: sanitized.videoUrl,
-      youtubeVideoId: sanitized.youtubeVideoId,
-      youtubeStartTime: sanitized.youtubeStartTime,
-      youtubeEndTime: sanitized.youtubeEndTime,
-      autoplay: sanitized.autoplay,
-      loop: sanitized.loop,
-      poster: sanitized.poster,
-      artist: sanitized.artist,
-      shape: sanitized.shape,
-      opacity: sanitized.opacity,
-      position: sanitized.position,
-      size: sanitized.size,
-      targetX: sanitized.targetX,
-      targetY: sanitized.targetY,
-      zoom: sanitized.zoom,
-      content: sanitized.content,
-      modalPosition: sanitized.modalPosition,
-      modalSize: sanitized.modalSize,
-      url: sanitized.url,
-      targetHotspotId: sanitized.targetHotspotId,
-      question: sanitized.question,
-      options: sanitized.options,
-      correctAnswer: sanitized.correctAnswer,
-      positioningVersion: sanitized.positioningVersion,
-      constraintsApplied: sanitized.constraintsApplied,
+      ...defaults,
+      ...sanitized,
     };
   }
 
   /**
-   * Sanitize hotspot data to remove undefined values and ensure defaults
+   * Sanitize hotspot data to remove undefined values
    * @param hotspot - Hotspot to sanitize
-   * @returns Sanitized hotspot with all fields present
+   * @returns Sanitized hotspot with undefined fields removed
    */
-  static sanitizeHotspot(hotspot: Partial<HotspotData>): HotspotData {
-    const sanitized = this.removeUndefinedFields(hotspot) as Partial<HotspotData>;
+  static sanitizeHotspot(hotspot: Partial<HotspotData>): Partial<HotspotData> {
+    const sanitized = this.removeUndefinedFields(hotspot);
 
+    // Validate that required fields exist to prevent Firebase errors
     if (!sanitized.id || sanitized.x === undefined || sanitized.y === undefined) {
       throw new Error(`Hotspot is missing required fields: ${JSON.stringify(hotspot)}`);
     }
 
-    // Return sanitized object with all fields present, providing defaults for optional fields
+    const defaults = {
+      title: '',
+      description: '',
+      size: 'medium' as const,
+      displayHotspotInEvent: false,
+    };
+
+    // Return sanitized object with validated required fields
     return {
-      id: sanitized.id,
-      x: sanitized.x,
-      y: sanitized.y,
-      title: sanitized.title || '',
-      description: sanitized.description || '',
-      color: sanitized.color,
-      backgroundColor: sanitized.backgroundColor,
-      size: sanitized.size || 'medium',
-      link: sanitized.link,
-      displayHotspotInEvent: sanitized.displayHotspotInEvent || false,
+      ...defaults,
+      ...sanitized,
     };
   }
 

--- a/src/lib/dataSanitizer.ts
+++ b/src/lib/dataSanitizer.ts
@@ -27,7 +27,7 @@ export class DataSanitizer {
    * @param event - Timeline event to sanitize
    * @returns Sanitized timeline event with all fields present
    */
-  static sanitizeTimelineEvent(event: TimelineEventData): TimelineEventData {
+  static sanitizeTimelineEvent(event: Partial<TimelineEventData>): TimelineEventData {
     const sanitized = this.removeUndefinedFields(event) as Partial<TimelineEventData>;
 
     if (!sanitized.id || sanitized.step === undefined || !sanitized.type) {
@@ -43,10 +43,10 @@ export class DataSanitizer {
       targetId: sanitized.targetId,
       message: sanitized.message,
       duration: sanitized.duration,
-      zoomFactor: sanitized.zoomFactor,
-      highlightRadius: sanitized.highlightRadius,
-      highlightShape: sanitized.highlightShape,
-      dimPercentage: sanitized.dimPercentage,
+      zoomFactor: sanitized.zoomFactor ?? 2,
+      highlightRadius: sanitized.highlightRadius ?? 60,
+      highlightShape: sanitized.highlightShape ?? 'circle',
+      dimPercentage: sanitized.dimPercentage ?? 70,
       spotlightX: sanitized.spotlightX,
       spotlightY: sanitized.spotlightY,
       spotlightWidth: sanitized.spotlightWidth,
@@ -105,7 +105,7 @@ export class DataSanitizer {
    * @param hotspot - Hotspot to sanitize
    * @returns Sanitized hotspot with all fields present
    */
-  static sanitizeHotspot(hotspot: HotspotData): HotspotData {
+  static sanitizeHotspot(hotspot: Partial<HotspotData>): HotspotData {
     const sanitized = this.removeUndefinedFields(hotspot) as Partial<HotspotData>;
 
     if (!sanitized.id || sanitized.x === undefined || sanitized.y === undefined) {

--- a/src/lib/firebaseApi.ts
+++ b/src/lib/firebaseApi.ts
@@ -512,7 +512,7 @@ export class FirebaseProjectAPI {
         return DataSanitizer.sanitizeHotspot({
           id: doc.id,
           ...data
-        } as HotspotData)
+        } as Partial<HotspotData>)
       })
     } catch (error) {
       console.error(`Error getting hotspots for project ${projectId}:`, error)
@@ -533,7 +533,7 @@ export class FirebaseProjectAPI {
         return DataSanitizer.sanitizeTimelineEvent({
           id: doc.id,
           ...data
-        } as TimelineEventData)
+        } as Partial<TimelineEventData>)
       })
     } catch (error) {
       console.error(`Error getting timeline events for project ${projectId}:`, error)

--- a/src/lib/firebaseApi.ts
+++ b/src/lib/firebaseApi.ts
@@ -512,7 +512,7 @@ export class FirebaseProjectAPI {
         return DataSanitizer.sanitizeHotspot({
           id: doc.id,
           ...data
-        } as Partial<HotspotData>)
+        }) as HotspotData
       })
     } catch (error) {
       console.error(`Error getting hotspots for project ${projectId}:`, error)
@@ -533,7 +533,7 @@ export class FirebaseProjectAPI {
         return DataSanitizer.sanitizeTimelineEvent({
           id: doc.id,
           ...data
-        } as Partial<TimelineEventData>)
+        }) as TimelineEventData
       })
     } catch (error) {
       console.error(`Error getting timeline events for project ${projectId}:`, error)

--- a/src/lib/firebaseApi.ts
+++ b/src/lib/firebaseApi.ts
@@ -509,15 +509,10 @@ export class FirebaseProjectAPI {
       
       return snapshot.docs.map(doc => {
         const data = doc.data()
-        return {
+        return DataSanitizer.sanitizeHotspot({
           id: doc.id,
-          x: data.x || 0,
-          y: data.y || 0,
-          title: data.title || '',
-          description: data.description || '',
-          color: data.color,
-          size: data.size || 'medium'
-        } as HotspotData
+          ...data
+        } as HotspotData)
       })
     } catch (error) {
       console.error(`Error getting hotspots for project ${projectId}:`, error)
@@ -535,17 +530,10 @@ export class FirebaseProjectAPI {
       
       return snapshot.docs.map(doc => {
         const data = doc.data()
-        return {
+        return DataSanitizer.sanitizeTimelineEvent({
           id: doc.id,
-          step: data.step || 1,
-          name: data.name || '',
-          type: data.type,
-          targetId: data.targetId,
-          message: data.message,
-          duration: data.duration,
-          zoomFactor: data.zoomFactor,
-          highlightRadius: data.highlightRadius
-        } as TimelineEventData
+          ...data
+        } as TimelineEventData)
       })
     } catch (error) {
       console.error(`Error getting timeline events for project ${projectId}:`, error)


### PR DESCRIPTION
This change updates the data sanitizer to ensure that all fields from the `HotspotData` and `TimelineEventData` types are present, with default values for optional fields.

It also updates the `firebaseApi.ts` to use the `DataSanitizer` when retrieving hotspots and timeline events, ensuring that the data returned from the API is complete and has all the necessary fields.