### PR TITLE
Fix(firestore): Add security rules for crossDeviceSync collection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -76,10 +76,10 @@ service cloud.firestore {
     }
 
     // Cross-device sync collection - used for real-time progress sharing
-    // This allows any authenticated user to read/write to sync documents.
-    // The data is not sensitive (just module position), so this is acceptable.
+    // This allows the project owner to read/write to sync documents.
+    // The rule ensures that a user can only access the sync data for projects they own.
     match /crossDeviceSync/{syncId} {
-      allow read, write: if isAuthenticated();
+      allow read, write: if isAuthenticated() && get(/databases/$(database)/documents/projects/$(syncId)).data.createdBy == request.auth.uid;
     }
     
     // Deny all other access

--- a/firestore.rules
+++ b/firestore.rules
@@ -74,6 +74,13 @@ service cloud.firestore {
     match /users/{userId} {
       allow read, write: if isAuthenticated() && isOwner(userId);
     }
+
+    // Cross-device sync collection - used for real-time progress sharing
+    // This allows any authenticated user to read/write to sync documents.
+    // The data is not sensitive (just module position), so this is acceptable.
+    match /crossDeviceSync/{syncId} {
+      allow read, write: if isAuthenticated();
+    }
     
     // Deny all other access
     match /{document=**} {


### PR DESCRIPTION
Adds read/write rules for the `crossDeviceSync` collection to resolve permission denied errors that were occurring in the mobile viewer when hotspots were activated. The `useCrossDeviceSync` hook was attempting to access this collection without any matching security rules.