### PR TITLE
I fixed hotspot visibility and event handling by:

### DIFF
--- a/src/client/components/EditableEventCard.tsx
+++ b/src/client/components/EditableEventCard.tsx
@@ -46,7 +46,6 @@ const EventTypeToggle: React.FC<{ type: InteractionType }> = ({ type }) => {
       case InteractionType.SHOW_AUDIO_MODAL:
         return 'audio';
       default:
-        // Fallback for other types like SHOW_HOTSPOT, HIDE_HOTSPOT, PULSE_HOTSPOT etc.
         return type.toLowerCase().replace(/_/g, ' ').replace('hotspot', '').trim();
     }
   };

--- a/src/client/components/EventTypeSelector.tsx
+++ b/src/client/components/EventTypeSelector.tsx
@@ -15,11 +15,6 @@ interface EventTypeSelectorProps {
 
 const eventTypeOptions: EventTypeOption[] = [
   {
-    value: InteractionType.SHOW_HOTSPOT,
-    label: 'Show Hotspot',
-    description: 'Make the hotspot visible'
-  },
-  {
     value: InteractionType.HIDE_HOTSPOT,
     label: 'Hide Hotspot',
     description: 'Hide the hotspot from view'

--- a/src/client/components/HotspotEditorToolbar.tsx
+++ b/src/client/components/HotspotEditorToolbar.tsx
@@ -36,7 +36,7 @@ const HotspotEditorToolbar: React.FC<HotspotEditorToolbarProps> = ({
   const [activeTab, setActiveTab] = useState<'properties' | 'events'>('properties');
   const [draggedEventId, setDraggedEventId] = useState<string | null>(null);
   const [showAddEventModal, setShowAddEventModal] = useState(false);
-  const [newEventType, setNewEventType] = useState<InteractionType>(InteractionType.SHOW_HOTSPOT);
+  const [newEventType, setNewEventType] = useState<InteractionType>(InteractionType.PULSE_HOTSPOT);
 
   const handleDeleteHotspot = () => {
     if (confirm(`Delete "${selectedHotspot.title}" and all its events?`)) {

--- a/src/client/components/HotspotViewer.tsx
+++ b/src/client/components/HotspotViewer.tsx
@@ -19,6 +19,7 @@ interface HotspotViewerProps {
   onDragStateChange?: (isDragging: boolean) => void; // Modified to accept boolean
   dragContainerRef?: React.RefObject<HTMLElement>; // Added new prop
   isActive?: boolean; // New prop to indicate if the hotspot is active
+  isExploreMode?: boolean; // New prop to indicate if the module is in explore mode
   /**
    * Callback triggered when a hotspot is double-tapped on a mobile device (and not in editing mode).
    * Used to initiate auto-focusing on the hotspot.
@@ -55,7 +56,8 @@ const HotspotViewer: React.FC<HotspotViewerProps> = (props) => {
     // imageElement, // Not directly used
     onDragStateChange,
     dragContainerRef,
-    isActive
+    isActive,
+    isExploreMode
   } = props;
 
   const { announceDragStart, announceDragStop } = useScreenReaderAnnouncements();
@@ -452,10 +454,6 @@ const getActualImageVisibleBounds = (
   const innerDotClasses = `absolute w-1/3 h-1/3 rounded-full bg-white/70 group-hover:bg-white/90 transition-opacity duration-150
     ${(hotspot.size === 'large' || (isMobile && hotspot.size !== 'small')) ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`;
 
-  // If an event is active for this hotspot, and the user has not opted to display it, render nothing.
-  if (isActive && !hotspot.displayHotspotInEvent) {
-    return null;
-  }
 
   return (
     <div

--- a/src/client/components/HotspotViewer.tsx
+++ b/src/client/components/HotspotViewer.tsx
@@ -19,7 +19,6 @@ interface HotspotViewerProps {
   onDragStateChange?: (isDragging: boolean) => void; // Modified to accept boolean
   dragContainerRef?: React.RefObject<HTMLElement>; // Added new prop
   isActive?: boolean; // New prop to indicate if the hotspot is active
-  isExploreMode?: boolean; // New prop to indicate if the module is in explore mode
   /**
    * Callback triggered when a hotspot is double-tapped on a mobile device (and not in editing mode).
    * Used to initiate auto-focusing on the hotspot.
@@ -56,8 +55,7 @@ const HotspotViewer: React.FC<HotspotViewerProps> = (props) => {
     // imageElement, // Not directly used
     onDragStateChange,
     dragContainerRef,
-    isActive,
-    isExploreMode
+    isActive
   } = props;
 
   const { announceDragStart, announceDragStop } = useScreenReaderAnnouncements();

--- a/src/client/components/ImageEditCanvas.tsx
+++ b/src/client/components/ImageEditCanvas.tsx
@@ -174,8 +174,7 @@ const ImageEditCanvas: React.FC<ImageEditCanvasProps> = React.memo(({
     return currentStep > 0 && !timelineEvents.some(e =>
       e.step === currentStep &&
       e.targetId === hotspotId &&
-      (e.type === InteractionType.SHOW_HOTSPOT ||
-       e.type === InteractionType.PULSE_HOTSPOT ||
+      (e.type === InteractionType.PULSE_HOTSPOT ||
        e.type === InteractionType.PAN_ZOOM_TO_HOTSPOT ||
        e.type === InteractionType.HIGHLIGHT_HOTSPOT)
     );

--- a/src/client/components/InteractiveModule.tsx
+++ b/src/client/components/InteractiveModule.tsx
@@ -1412,19 +1412,8 @@ const InteractiveModule: React.FC<InteractiveModuleProps> = ({
     setSelectedHotspotForModal(newHotspotData.id);
     setIsHotspotModalOpen(true);
 
-    // Optional: Create a default "SHOW_HOTSPOT" timeline event
-    const newEventStep = timelineEvents.length > 0 ? Math.max(...timelineEvents.map(e => e.step), 0) + 1 : 1;
-    const newShowEvent: TimelineEventData = {
-      id: `te_show_${newHotspotData.id}_${Date.now()}`,
-      step: newEventStep,
-      name: `Show ${newHotspotData.title}`,
-      type: InteractionType.SHOW_HOTSPOT,
-      targetId: newHotspotData.id,
-      message: ''
-    };
-    setTimelineEvents(prevEvents => [...prevEvents, newShowEvent].sort((a,b) => a.step - b.step));
-    
     if (isEditing) {
+      const newEventStep = timelineEvents.length > 0 ? Math.max(...timelineEvents.map(e => e.step), 0) + 1 : 1;
       setCurrentStep(newEventStep);
     }
 
@@ -2400,13 +2389,13 @@ const InteractiveModule: React.FC<InteractiveModuleProps> = ({
     // Removed newActiveHotspotInfoId - using modal now
     let newImageTransform: ImageTransformState = lastAppliedTransformRef.current || { scale: 1, translateX: 0, translateY: 0, targetHotspotId: undefined };
 
+    const eventsForCurrentStep = timelineEvents.filter(event => event.step === currentStep);
     if (moduleState === 'learning') {
       const newActiveDisplayIds = new Set<string>();
       let newMessage: string | null = null;
       let newPulsingHotspotId: string | null = null;
       let newHighlightedHotspotId: string | null = null;
 
-      const eventsForCurrentStep = timelineEvents.filter(event => event.step === currentStep);
       
       // Debug logging for mobile event execution
       console.log('🎯 Event Execution Debug:', {
@@ -2419,11 +2408,27 @@ const InteractiveModule: React.FC<InteractiveModuleProps> = ({
       });
       let stepHasPanZoomEvent = false;
 
+      if (moduleState === 'idle') {
+        const activeEventHotspotIds = new Set(eventsForCurrentStep.map(e => e.targetId));
+        hotspots.forEach(h => {
+            if (!activeEventHotspotIds.has(h.id) || h.displayHotspotInEvent) {
+                newActiveDisplayIds.add(h.id);
+            }
+        });
+      } else { // learning mode
+        eventsForCurrentStep.forEach(event => {
+            if (event.targetId) {
+                const hotspot = hotspots.find(h => h.id === event.targetId);
+                if (hotspot && hotspot.displayHotspotInEvent) {
+                    newActiveDisplayIds.add(event.targetId);
+                }
+            }
+        });
+      }
+
       eventsForCurrentStep.forEach(event => {
-        if (event.targetId) newActiveDisplayIds.add(event.targetId);
         switch (event.type) {
           case InteractionType.SHOW_MESSAGE: if (event.message) newMessage = event.message; break;
-          case InteractionType.SHOW_HOTSPOT: if (event.targetId) { /* Show in modal instead */ } break;
           case InteractionType.PULSE_HOTSPOT:
             if (event.targetId) {
               newPulsingHotspotId = event.targetId;
@@ -2666,7 +2671,14 @@ const InteractiveModule: React.FC<InteractiveModuleProps> = ({
       });
 
     } else if (moduleState === 'idle' && !isEditing) {
-      setActiveHotspotDisplayIds(new Set(hotspots.map(h => h.id)));
+      const activeEventHotspotIds = new Set(eventsForCurrentStep.map(e => e.targetId));
+      const newActiveDisplayIds = new Set<string>();
+      hotspots.forEach(h => {
+        if (!activeEventHotspotIds.has(h.id) || h.displayHotspotInEvent) {
+            newActiveDisplayIds.add(h.id);
+        }
+      });
+      setActiveHotspotDisplayIds(newActiveDisplayIds);
       setCurrentMessage(null);
       setPulsingHotspotId(null);
       setHighlightedHotspotId(null);
@@ -3036,22 +3048,7 @@ const InteractiveModule: React.FC<InteractiveModuleProps> = ({
                         ))}
                       </div>
                       <div className="mt-2">
-                        <strong>Show Events:</strong>
-                        {timelineEvents.filter(e => e.type === InteractionType.SHOW_HOTSPOT).map(e => (
-                          <div key={e.id} className="ml-2">Step {e.step}: {e.targetId}</div>
-                        ))}
-                      </div>
-                      <div className="mt-2">
                         <strong>Current Step:</strong> {currentStep}
-                      </div>
-                      <div>
-                        <strong>Visible Hotspots:</strong> {hotspots.filter(h => 
-                          timelineEvents.some(e => 
-                            e.type === InteractionType.SHOW_HOTSPOT && 
-                            e.targetId === h.id && 
-                            e.step <= currentStep
-                          )
-                        ).length}
                       </div>
                     </div>
                   )}
@@ -3268,6 +3265,7 @@ const InteractiveModule: React.FC<InteractiveModuleProps> = ({
                               isMobile={isMobile}
                               onDragStateChange={setIsHotspotDragging}
                               isActive={activeHotspotDisplayIds.has(hotspot.id)}
+                              isExploreMode={moduleState === 'idle'}
                             />
                           );
                         })}

--- a/src/client/components/MobileHotspotEditor.tsx
+++ b/src/client/components/MobileHotspotEditor.tsx
@@ -48,7 +48,6 @@ const HOTSPOT_SIZES = [
 
 // Simplified interaction types for mobile, can be expanded later
 const INTERACTION_TYPE_OPTIONS = [
-  { value: InteractionType.SHOW_HOTSPOT, label: 'Show Hotspot' },
   { value: InteractionType.PULSE_HOTSPOT, label: 'Pulse Hotspot' },
   // { value: InteractionType.HIGHLIGHT_HOTSPOT, label: 'Highlight Area' }, // More complex, defer if needed
   // { value: InteractionType.PAN_ZOOM_TO_HOTSPOT, label: 'Zoom to Hotspot' }, // More complex, defer if needed

--- a/src/client/components/StreamlinedHotspotEditor.tsx
+++ b/src/client/components/StreamlinedHotspotEditor.tsx
@@ -139,7 +139,6 @@ const StreamlinedHotspotEditor: React.FC<StreamlinedHotspotEditorProps> = ({
 
   const getEventIcon = (type: InteractionType) => {
     const icons: Record<InteractionType, string> = {
-      [InteractionType.SHOW_HOTSPOT]: 'Show',
       [InteractionType.HIDE_HOTSPOT]: 'Hide',
       [InteractionType.PULSE_HOTSPOT]: 'Pulse',
       [InteractionType.SHOW_MESSAGE]: 'Text',
@@ -397,7 +396,7 @@ const EventEditorForm: React.FC<EventEditorFormProps> = ({ event, hotspotId, onS
   const [formData, setFormData] = useState<Partial<TimelineEventData>>(() => ({
     id: event?.id || `event_${Date.now()}`,
     name: event?.name || 'New Event',
-    type: event?.type || InteractionType.SHOW_HOTSPOT,
+    type: event?.type || InteractionType.PULSE_HOTSPOT,
     targetId: hotspotId,
     message: event?.message || '',
     duration: event?.duration || 2000,
@@ -516,7 +515,6 @@ const EventEditorForm: React.FC<EventEditorFormProps> = ({ event, hotspotId, onS
             onChange={(e) => setFormData(prev => ({ ...prev, type: e.target.value as InteractionType }))}
             className="w-full bg-slate-700 border border-slate-600 rounded px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-purple-500"
           >
-            <option value={InteractionType.SHOW_HOTSPOT}>Show Hotspot</option>
             <option value={InteractionType.HIDE_HOTSPOT}>Hide Hotspot</option>
             <option value={InteractionType.PULSE_HOTSPOT}>Pulse Hotspot</option>
             <option value={InteractionType.SHOW_MESSAGE}>Show Message</option>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3,7 +3,6 @@ import { Timestamp } from 'firebase/firestore';
 
 export enum InteractionType {
   // Existing types
-  SHOW_HOTSPOT = 'SHOW_HOTSPOT',
   HIDE_HOTSPOT = 'HIDE_HOTSPOT',
   PULSE_HOTSPOT = 'PULSE_HOTSPOT',
   SHOW_MESSAGE = 'SHOW_MESSAGE',

--- a/src/tests/eventSystem.test.ts
+++ b/src/tests/eventSystem.test.ts
@@ -7,7 +7,6 @@ describe('Event System', () => {
   describe('InteractionType Enum', () => {
     test('should have all required interaction types', () => {
       const expectedTypes = [
-        'SHOW_HOTSPOT',
         'HIDE_HOTSPOT', 
         'PULSE_HOTSPOT',
         'SHOW_MESSAGE',
@@ -253,13 +252,6 @@ describe('Event System', () => {
     test('should handle multiple events in sequence', () => {
       const events: TimelineEventData[] = [
         {
-          id: 'event-1',
-          step: 1,
-          name: 'Show First Hotspot',
-          type: InteractionType.SHOW_HOTSPOT,
-          targetId: 'hotspot-1'
-        },
-        {
           id: 'event-2',
           step: 2,
           name: 'Display Message',
@@ -276,21 +268,13 @@ describe('Event System', () => {
         }
       ]
 
-      expect(events).toHaveLength(3)
-      expect(events[0].step).toBe(1)
-      expect(events[1].step).toBe(2)
-      expect(events[2].step).toBe(3)
+      expect(events).toHaveLength(2)
+      expect(events[0].step).toBe(2)
+      expect(events[1].step).toBe(3)
     })
 
     test('should handle multiple events in the same step', () => {
       const events: TimelineEventData[] = [
-        {
-          id: 'event-1',
-          step: 1,
-          name: 'Show Hotspot',
-          type: InteractionType.SHOW_HOTSPOT,
-          targetId: 'hotspot-1'
-        },
         {
           id: 'event-2',
           step: 1,
@@ -302,7 +286,7 @@ describe('Event System', () => {
       ]
 
       const step1Events = events.filter(e => e.step === 1)
-      expect(step1Events).toHaveLength(2)
+      expect(step1Events).toHaveLength(1)
       expect(step1Events.every(e => e.targetId === 'hotspot-1')).toBe(true)
     })
   })
@@ -329,7 +313,7 @@ describe('Event System', () => {
         id: 'test-1',
         step: 1,
         name: 'Invalid Target',
-        type: InteractionType.SHOW_HOTSPOT,
+        type: InteractionType.PULSE_HOTSPOT,
         targetId: 'non-existent-hotspot'
       }
 

--- a/src/tests/timelineEventExecution.test.ts
+++ b/src/tests/timelineEventExecution.test.ts
@@ -26,13 +26,6 @@ describe('Timeline Event Execution', () => {
 
     mockTimelineEvents = [
       {
-        id: 'event-1',
-        step: 1,
-        name: 'Show First Hotspot',
-        type: InteractionType.SHOW_HOTSPOT,
-        targetId: 'hotspot-1'
-      },
-      {
         id: 'event-2',
         step: 2,
         name: 'Show Message',
@@ -62,12 +55,8 @@ describe('Timeline Event Execution', () => {
 
   describe('Event Filtering by Step', () => {
     test('should filter events for specific step', () => {
-      const step1Events = mockTimelineEvents.filter(event => event.step === 1)
       const step2Events = mockTimelineEvents.filter(event => event.step === 2)
       const step3Events = mockTimelineEvents.filter(event => event.step === 3)
-
-      expect(step1Events).toHaveLength(1)
-      expect(step1Events[0].type).toBe(InteractionType.SHOW_HOTSPOT)
 
       expect(step2Events).toHaveLength(1)
       expect(step2Events[0].type).toBe(InteractionType.SHOW_MESSAGE)
@@ -78,13 +67,6 @@ describe('Timeline Event Execution', () => {
 
     test('should handle steps with multiple events', () => {
       const multiEventTimeline: TimelineEventData[] = [
-        {
-          id: 'event-1',
-          step: 1,
-          name: 'Show Hotspot',
-          type: InteractionType.SHOW_HOTSPOT,
-          targetId: 'hotspot-1'
-        },
         {
           id: 'event-2',
           step: 1,
@@ -103,26 +85,17 @@ describe('Timeline Event Execution', () => {
       ]
 
       const step1Events = multiEventTimeline.filter(event => event.step === 1)
-      expect(step1Events).toHaveLength(3)
+      expect(step1Events).toHaveLength(2)
     })
   })
 
   describe('Event Target Resolution', () => {
-    test('should resolve valid hotspot targets', () => {
-      const event = mockTimelineEvents.find(e => e.type === InteractionType.SHOW_HOTSPOT)
-      expect(event?.targetId).toBe('hotspot-1')
-
-      const targetHotspot = mockHotspots.find(h => h.id === event?.targetId)
-      expect(targetHotspot).toBeDefined()
-      expect(targetHotspot?.id).toBe('hotspot-1')
-    })
-
     test('should handle invalid hotspot targets', () => {
       const invalidEvent: TimelineEventData = {
         id: 'invalid-event',
         step: 1,
         name: 'Invalid Target',
-        type: InteractionType.SHOW_HOTSPOT,
+        type: InteractionType.PULSE_HOTSPOT,
         targetId: 'non-existent-hotspot'
       }
 
@@ -365,20 +338,6 @@ describe('Timeline Event Execution', () => {
   })
 
   describe('Event State Management', () => {
-    test('should track active hotspot display state', () => {
-      const activeDisplayIds = new Set<string>()
-
-      // Process SHOW_HOTSPOT events
-      const showEvents = mockTimelineEvents.filter(e => e.type === InteractionType.SHOW_HOTSPOT)
-      showEvents.forEach(event => {
-        if (event.targetId) {
-          activeDisplayIds.add(event.targetId)
-        }
-      })
-
-      expect(activeDisplayIds.has('hotspot-1')).toBe(true)
-    })
-
     test('should handle HIDE_HOTSPOT events', () => {
       const activeDisplayIds = new Set(['hotspot-1', 'hotspot-2'])
 


### PR DESCRIPTION
- Removing the redundant `SHOW_HOTSPOT` event and making hotspots visible by default.
- Implementing new logic for the 'Show/hide hotspot during event' toggle to provide more intuitive behavior in both 'explore' and 'guided learning' modes.
- Refactoring `InteractiveModule.tsx` to centralize and simplify hotspot visibility logic.