### PR TITLE
Fix: Mobile Editor Bugs

### DIFF
--- a/src/client/components/MobileEditorModal.tsx
+++ b/src/client/components/MobileEditorModal.tsx
@@ -26,6 +26,8 @@ interface MobileEditorModalProps {
   onAddTimelineEvent: (event: TimelineEventData) => void;
   onUpdateTimelineEvent: (event: TimelineEventData) => void;
   onDeleteTimelineEvent: (eventId: string) => void;
+  onInteractionStart?: () => void;
+  onInteractionEnd?: () => void;
 }
 
 interface KeyboardState {
@@ -175,23 +177,26 @@ const MobileEditorModal: React.FC<MobileEditorModalProps> = ({
   }, [isEditingHotspot, onInteractionStart, onInteractionEnd]);
 
   useEffect(() => {
-    const handleFocusIn = (e: FocusEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
-        setIsEditingHotspot(true);
-      }
-    };
-    const handleFocusOut = (e: FocusEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
-        setIsEditingHotspot(false);
-      }
-    };
-    document.addEventListener('focusin', handleFocusIn);
-    document.addEventListener('focusout', handleFocusOut);
-    return () => {
-      document.removeEventListener('focusin', handleFocusIn);
-      document.removeEventListener('focusout', handleFocusOut);
-    };
-  }, []);
+    const modal = modalRef.current;
+    if (modal) {
+      const handleFocusIn = (e: FocusEvent) => {
+        if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+          setIsEditingHotspot(true);
+        }
+      };
+      const handleFocusOut = (e: FocusEvent) => {
+        if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+          setIsEditingHotspot(false);
+        }
+      };
+      modal.addEventListener('focusin', handleFocusIn);
+      modal.addEventListener('focusout', handleFocusOut);
+      return () => {
+        modal.removeEventListener('focusin', handleFocusIn);
+        modal.removeEventListener('focusout', handleFocusOut);
+      };
+    }
+  }, [modalRef]);
 
   // Auto-save functionality with debouncing
   const autoSaveTimeoutRef = useRef<number>();

--- a/src/client/hooks/useViewportHeight.ts
+++ b/src/client/hooks/useViewportHeight.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 
 function getViewportHeight() {
-  return window.innerHeight;
+  return window.visualViewport ? window.visualViewport.height : window.innerHeight;
 }
 
 export function useViewportHeight() {
@@ -10,6 +10,13 @@ export function useViewportHeight() {
   useEffect(() => {
     function handleResize() {
       setHeight(getViewportHeight());
+    }
+
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener('resize', handleResize);
+      return () => {
+        window.visualViewport.removeEventListener('resize', handleResize);
+      };
     }
 
     window.addEventListener('resize', handleResize);

--- a/src/client/hooks/useViewportHeight.ts
+++ b/src/client/hooks/useViewportHeight.ts
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react';
+
+function getViewportHeight() {
+  return window.innerHeight;
+}
+
+export function useViewportHeight() {
+  const [height, setHeight] = useState(getViewportHeight());
+
+  useEffect(() => {
+    function handleResize() {
+      setHeight(getViewportHeight());
+    }
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return height;
+}

--- a/src/client/utils/mobileStateManager.ts
+++ b/src/client/utils/mobileStateManager.ts
@@ -1,9 +1,9 @@
-import { Hotspot } from '../../types/hotspot';
+import { HotspotData } from '../../shared/types';
 
 const STATE_KEY = 'mobileEditorState';
 
 export interface MobileEditorState {
-  hotspots: Hotspot[];
+  hotspots: HotspotData[];
   selectedHotspotId?: string;
 }
 

--- a/src/client/utils/mobileStateManager.ts
+++ b/src/client/utils/mobileStateManager.ts
@@ -1,0 +1,40 @@
+import { Hotspot } from '../../types/hotspot';
+
+const STATE_KEY = 'mobileEditorState';
+
+export interface MobileEditorState {
+  hotspots: Hotspot[];
+  selectedHotspotId?: string;
+}
+
+export const mobileStateManager = {
+  saveState: (state: MobileEditorState) => {
+    try {
+      const serializedState = JSON.stringify(state);
+      sessionStorage.setItem(STATE_KEY, serializedState);
+    } catch (error) {
+      console.error('Error saving mobile editor state:', error);
+    }
+  },
+
+  loadState: (): MobileEditorState | null => {
+    try {
+      const serializedState = sessionStorage.getItem(STATE_KEY);
+      if (serializedState === null) {
+        return null;
+      }
+      return JSON.parse(serializedState);
+    } catch (error) {
+      console.error('Error loading mobile editor state:', error);
+      return null;
+    }
+  },
+
+  clearState: () => {
+    try {
+      sessionStorage.removeItem(STATE_KEY);
+    } catch (error) {
+      console.error('Error clearing mobile editor state:', error);
+    }
+  },
+};


### PR DESCRIPTION
This commit addresses several issues in the mobile editor:

- Editor Modal: The editor modal now correctly handles the appearance of the on-screen keyboard by using a `useViewportHeight` hook to adjust its height dynamically.
- Touch Conflicts: Pan/zoom gestures on the underlying image are now disabled when you are editing a hotspot, preventing touch conflicts.
- State Persistence: Edits are now persisted across orientation changes by saving the editor state to `sessionStorage` using a new `mobileStateManager` utility.