### PR TITLE
Fix: Remove viewer mode banner

### DIFF
--- a/src/client/components/ViewerToolbar.tsx
+++ b/src/client/components/ViewerToolbar.tsx
@@ -82,12 +82,6 @@ const ViewerToolbar: React.FC<ViewerToolbarProps> = ({
             <AuthButton variant="compact" />
           </div>
         </div>
-        {/* Conditional Message for Learning Mode */}
-        {moduleState === 'learning' && (
-           <div className="px-3 pb-2 text-center bg-slate-700/30"> {/* Adjusted padding and added subtle background */}
-             <p className="text-xs text-sky-300">Using timeline to navigate tour steps.</p> {/* More prominent text color */}
-          </div>
-        )}
       </div>
     );
   }


### PR DESCRIPTION
This commit removes the banner in the viewer mode that says "Using timeline to navigate tour steps." It was taking up unnecessary space.