### PR TITLE
fix: Center pan-zoom on hotspot

### DIFF
--- a/src/client/components/HotspotEditorModal.tsx
+++ b/src/client/components/HotspotEditorModal.tsx
@@ -209,6 +209,8 @@ const EnhancedHotspotEditorModal: React.FC<EnhancedHotspotEditorModalProps> = ({
       
       // === UNIFIED PAN_ZOOM PROPERTIES ===
       ...(type === InteractionType.PAN_ZOOM && {
+        targetX: localHotspot.x,
+        targetY: localHotspot.y,
         zoomLevel: 2,
         smooth: true,
       }),

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/vitest'
-import { vi } from 'vitest'
+import { vi, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
 
 // Mock Firebase Analytics
 vi.mock('@firebase/analytics', () => ({
@@ -20,4 +21,9 @@ Object.defineProperty(window, 'matchMedia', {
     removeEventListener: vi.fn(),
     dispatchEvent: vi.fn(),
   })),
+});
+
+// Clean up jsdom after each test
+afterEach(() => {
+  cleanup();
 });


### PR DESCRIPTION
The default positioning of the pan zoom shape is now centered on the hotspot.