### PR TITLE
fix: Reset pan and zoom on timeline navigation

### DIFF
--- a/src/client/components/InteractiveViewer.tsx
+++ b/src/client/components/InteractiveViewer.tsx
@@ -154,29 +154,37 @@ const InteractiveViewer: React.FC<InteractiveViewerProps> = ({
 
   const handlePrevStep = useCallback(() => {
     if (currentStepIndex > 0) {
-      // Reset pan & zoom when moving to previous step
-      setImageTransform(prev => ({
-        scale: 1,
-        translateX: 0,
-        translateY: 0,
-        targetHotspotId: undefined
-      }));
+      const currentEvents = timelineEvents.filter(event => event.step === currentStep);
+      const isPanZoomEvent = currentEvents.some(event => event.type === InteractionType.PAN_ZOOM || event.type === InteractionType.PAN_ZOOM_TO_HOTSPOT);
+
+      if (isPanZoomEvent || isTransforming) {
+        setImageTransform({
+          scale: 1,
+          translateX: 0,
+          translateY: 0,
+          targetHotspotId: undefined
+        });
+      }
       setCurrentStep(uniqueSortedSteps[currentStepIndex - 1]);
     }
-  }, [currentStepIndex, uniqueSortedSteps]);
+  }, [currentStepIndex, uniqueSortedSteps, timelineEvents, currentStep, isTransforming]);
 
   const handleNextStep = useCallback(() => {
     if (currentStepIndex < uniqueSortedSteps.length - 1) {
-      // Reset pan & zoom when moving to next step
-      setImageTransform(prev => ({
-        scale: 1,
-        translateX: 0,
-        translateY: 0,
-        targetHotspotId: undefined
-      }));
+      const currentEvents = timelineEvents.filter(event => event.step === currentStep);
+      const isPanZoomEvent = currentEvents.some(event => event.type === InteractionType.PAN_ZOOM || event.type === InteractionType.PAN_ZOOM_TO_HOTSPOT);
+
+      if (isPanZoomEvent || isTransforming) {
+        setImageTransform({
+          scale: 1,
+          translateX: 0,
+          translateY: 0,
+          targetHotspotId: undefined
+        });
+      }
       setCurrentStep(uniqueSortedSteps[currentStepIndex + 1]);
     }
-  }, [currentStepIndex, uniqueSortedSteps]);
+  }, [currentStepIndex, uniqueSortedSteps, timelineEvents, currentStep, isTransforming]);
 
   const handleMobileEventComplete = useCallback(() => {
     setMobileActiveEvents([]);


### PR DESCRIPTION
When in the mobile viewer, if the active hotspot event type is pan & zoom, the view was not reverting to the original view when clicking next in the timeline. This change ensures that the pan and zoom state is reset when you navigate to the next or previous step in the timeline.