### PR TITLE
fix: Ensure modals appear on mobile when navigating timeline

### DIFF
--- a/src/client/components/InteractiveViewer.tsx
+++ b/src/client/components/InteractiveViewer.tsx
@@ -139,48 +139,40 @@ const InteractiveViewer: React.FC<InteractiveViewerProps> = ({
     }
   }, [moduleState, isMobile, timelineEvents]);
 
-  const handleTimelineDotClick = useCallback((step: number) => {
-    // Reset pan & zoom when moving to a different step
-    setImageTransform(prev => ({
+  // Helper function to reset transform state - extracted to reduce duplication
+  const resetTransform = useCallback(() => {
+    setImageTransform({
       scale: 1,
       translateX: 0,
       translateY: 0,
       targetHotspotId: undefined
-    }));
+    });
+    setIsTransformingFromGestures(false);
+  }, []);
+
+  const handleTimelineDotClick = useCallback((step: number) => {
+    // Reset pan & zoom when moving to a different step
+    resetTransform();
     setCurrentStep(step);
     if (moduleState === 'idle') {
       setModuleState('learning');
       setHasUserChosenMode(true);
     }
-  }, [moduleState]);
+  }, [moduleState, resetTransform]);
 
   const handlePrevStep = useCallback(() => {
     if (currentStepIndex > 0) {
-      // Always reset transform when navigating steps
-      setImageTransform({
-        scale: 1,
-        translateX: 0,
-        translateY: 0,
-        targetHotspotId: undefined
-      });
-      setIsTransformingFromGestures(false); // Reset gesture state as well
+      resetTransform();
       setCurrentStep(uniqueSortedSteps[currentStepIndex - 1]);
     }
-  }, [currentStepIndex, uniqueSortedSteps]);
+  }, [currentStepIndex, uniqueSortedSteps, resetTransform]);
 
   const handleNextStep = useCallback(() => {
     if (currentStepIndex < uniqueSortedSteps.length - 1) {
-      // Always reset transform when navigating steps
-      setImageTransform({
-        scale: 1,
-        translateX: 0,
-        translateY: 0,
-        targetHotspotId: undefined
-      });
-      setIsTransformingFromGestures(false); // Reset gesture state as well
+      resetTransform();
       setCurrentStep(uniqueSortedSteps[currentStepIndex + 1]);
     }
-  }, [currentStepIndex, uniqueSortedSteps]);
+  }, [currentStepIndex, uniqueSortedSteps, resetTransform]);
 
   const handleMobileEventComplete = useCallback(() => {
     setMobileActiveEvents([]);

--- a/src/client/components/InteractiveViewer.tsx
+++ b/src/client/components/InteractiveViewer.tsx
@@ -68,9 +68,11 @@ const InteractiveViewer: React.FC<InteractiveViewerProps> = ({
   const viewerTimelineRef = useRef<HTMLDivElement>(null);
   
   // Transform constraints and utilities
+  const [isTransformingFromGestures, setIsTransformingFromGestures] = useState(false);
   const isTransforming = useMemo(() => {
-    return imageTransform.scale !== 1 || imageTransform.translateX !== 0 || imageTransform.translateY !== 0;
-  }, [imageTransform]);
+    const isProgrammaticTransform = imageTransform.scale !== 1 || imageTransform.translateX !== 0 || imageTransform.translateY !== 0;
+    return isProgrammaticTransform || isTransformingFromGestures;
+  }, [imageTransform, isTransformingFromGestures]);
 
   // Touch gesture handling
   const {
@@ -84,7 +86,7 @@ const InteractiveViewer: React.FC<InteractiveViewerProps> = ({
     imageContainerRef,
     imageTransform,
     (transform) => setImageTransform(prev => ({ ...prev, ...transform })),
-    () => {}, // setIsTransforming - not needed for viewer
+    setIsTransformingFromGestures, // Correctly pass the setter
     {
       isDragging: false,
       isEditing: false
@@ -154,37 +156,31 @@ const InteractiveViewer: React.FC<InteractiveViewerProps> = ({
 
   const handlePrevStep = useCallback(() => {
     if (currentStepIndex > 0) {
-      const currentEvents = timelineEvents.filter(event => event.step === currentStep);
-      const isPanZoomEvent = currentEvents.some(event => event.type === InteractionType.PAN_ZOOM || event.type === InteractionType.PAN_ZOOM_TO_HOTSPOT);
-
-      if (isPanZoomEvent || isTransforming) {
-        setImageTransform({
-          scale: 1,
-          translateX: 0,
-          translateY: 0,
-          targetHotspotId: undefined
-        });
-      }
+      // Always reset transform when navigating steps
+      setImageTransform({
+        scale: 1,
+        translateX: 0,
+        translateY: 0,
+        targetHotspotId: undefined
+      });
+      setIsTransformingFromGestures(false); // Reset gesture state as well
       setCurrentStep(uniqueSortedSteps[currentStepIndex - 1]);
     }
-  }, [currentStepIndex, uniqueSortedSteps, timelineEvents, currentStep, isTransforming]);
+  }, [currentStepIndex, uniqueSortedSteps]);
 
   const handleNextStep = useCallback(() => {
     if (currentStepIndex < uniqueSortedSteps.length - 1) {
-      const currentEvents = timelineEvents.filter(event => event.step === currentStep);
-      const isPanZoomEvent = currentEvents.some(event => event.type === InteractionType.PAN_ZOOM || event.type === InteractionType.PAN_ZOOM_TO_HOTSPOT);
-
-      if (isPanZoomEvent || isTransforming) {
-        setImageTransform({
-          scale: 1,
-          translateX: 0,
-          translateY: 0,
-          targetHotspotId: undefined
-        });
-      }
+      // Always reset transform when navigating steps
+      setImageTransform({
+        scale: 1,
+        translateX: 0,
+        translateY: 0,
+        targetHotspotId: undefined
+      });
+      setIsTransformingFromGestures(false); // Reset gesture state as well
       setCurrentStep(uniqueSortedSteps[currentStepIndex + 1]);
     }
-  }, [currentStepIndex, uniqueSortedSteps, timelineEvents, currentStep, isTransforming]);
+  }, [currentStepIndex, uniqueSortedSteps]);
 
   const handleMobileEventComplete = useCallback(() => {
     setMobileActiveEvents([]);


### PR DESCRIPTION
The previous implementation had a bug where modals would not appear on mobile devices when navigating the timeline, especially after a pan/zoom event. This was because the `isTransforming` state was not being correctly managed in the `InteractiveViewer` component.

This commit fixes the issue by:

1.  Introducing a new state variable `isTransformingFromGestures` to specifically track transformations originating from user gestures.
2.  Passing the `setIsTransformingFromGestures` setter to the `useTouchGestures` hook.
3.  Updating the `isTransforming` logic to consider both programmatic and gesture-based transformations.
4.  Simplifying the `handleNextStep` and `handlePrevStep` functions to always reset the transformation state when navigating between steps.