### PR TITLE
feat(mobile): Implement mobile audio settings editor

### DIFF
--- a/src/client/components/EditableEventCard.tsx
+++ b/src/client/components/EditableEventCard.tsx
@@ -18,6 +18,7 @@ interface EditableEventCardProps {
   onDelete: (eventId: string) => void;
   moveCard: (dragIndex: number, hoverIndex: number) => void;
   onTogglePreview: () => void;
+  onEdit: () => void;
   isPreviewing: boolean;
   // isBeingDragged?: boolean; // This will be determined by the useDrag hook within this component
   allHotspots: HotspotData[];
@@ -65,6 +66,7 @@ const EditableEventCard: React.FC<EditableEventCardProps> = ({
   onDelete,
   moveCard,
   onTogglePreview,
+  onEdit,
   isPreviewing,
   allHotspots,
   isActive = false,
@@ -682,11 +684,29 @@ const EditableEventCard: React.FC<EditableEventCardProps> = ({
             {isPreviewing ? ( <EyeSlashIcon className="w-5 h-5" /> ) : ( <EyeIcon className="w-5 h-5" /> )}
           </button>
           <button
-            onClick={(e) => { e.stopPropagation(); setIsEditingTitle(!isEditingTitle); }}
+            onClick={(e) => {
+              e.stopPropagation();
+              if (event.type === InteractionType.PLAY_AUDIO || event.type === InteractionType.PLAY_VIDEO) {
+                onEdit();
+              } else {
+                setIsEditingTitle(!isEditingTitle);
+              }
+            }}
             className="p-1.5 text-slate-400 hover:text-white rounded-md hover:bg-slate-700 dark:text-slate-500 dark:hover:text-slate-300 dark:hover:bg-slate-800 transition-colors"
-            aria-label="Edit Title"
+            aria-label={
+              event.type === InteractionType.PLAY_AUDIO || event.type === InteractionType.PLAY_VIDEO
+                ? 'Edit Event Settings'
+                : 'Edit Title'
+            }
           >
-            <PencilIcon className="w-4 h-4" />
+            {event.type === InteractionType.PLAY_AUDIO || event.type === InteractionType.PLAY_VIDEO ? (
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+            ) : (
+              <PencilIcon className="w-4 h-4" />
+            )}
           </button>
           <button
             onClick={(e) => { e.stopPropagation(); onDelete(event.id); }}

--- a/src/client/components/EditableEventCard.tsx
+++ b/src/client/components/EditableEventCard.tsx
@@ -77,6 +77,7 @@ const EditableEventCard: React.FC<EditableEventCardProps> = ({
   const [title, setTitle] = useState(event.name || '');
   const cardRef = useRef<HTMLDivElement>(null);
   const dragHandleRef = useRef<HTMLDivElement>(null);
+  const quizIdCounter = useRef(0);
 
   const [{ handlerId }, drop] = useDrop<
     { id: string; index: number; type: string }, // item object type from useDrag
@@ -128,7 +129,7 @@ const EditableEventCard: React.FC<EditableEventCardProps> = ({
   // Quiz trigger helper functions
   const addQuizTrigger = (event: TimelineEventData) => {
     const newTrigger: MediaQuizTrigger = {
-      id: `quiz-${Date.now()}`,
+      id: `quiz-${++quizIdCounter.current}`,
       timestamp: 0,
       pauseMedia: true,
       quiz: {

--- a/src/client/components/HotspotEditorModal.tsx
+++ b/src/client/components/HotspotEditorModal.tsx
@@ -12,6 +12,7 @@ import EventTypeToggle from './EventTypeToggle';
 import PanZoomSettings from './PanZoomSettings';
 import SpotlightSettings from './SpotlightSettings';
 import EditableEventCard from './EditableEventCard';
+import MobilePlayAudioEditor from './MobilePlayAudioEditor';
 import { normalizeHotspotPosition } from '../../lib/safeMathUtils';
 
 interface EnhancedHotspotEditorModalProps {
@@ -129,6 +130,7 @@ const EnhancedHotspotEditorModal: React.FC<EnhancedHotspotEditorModalProps> = ({
   // Local state for the hotspot being edited
   const [localHotspot, setLocalHotspot] = useState(selectedHotspot);
   const [previewingEventIds, setPreviewingEventIds] = useState<string[]>([]);
+  const [editingEvent, setEditingEvent] = useState<TimelineEventData | null>(null);
   const [showEventTypeSelector, setShowEventTypeSelector] = useState(false); // New state for EventTypeSelector visibility
   const [isCollapsed, setIsCollapsed] = useState(false); // New state for collapse/expand
   const eventTypeSelectorRef = useRef<HTMLDivElement>(null); // Ref for scrolling
@@ -438,22 +440,33 @@ const EnhancedHotspotEditorModal: React.FC<EnhancedHotspotEditorModalProps> = ({
                     No events for this hotspot. Click "Add Event" to create one.
                   </div>
                 )}
-                {localHotspotEvents?.map((event, index) => 
-                  <EditableEventCard 
-                    key={event.id} 
-                    index={index} 
-                    event={event} 
-                    onUpdate={handleEventUpdate} 
-                    onDelete={handleEventDelete} 
-                    moveCard={moveEvent} 
-                    onTogglePreview={() => handleTogglePreview(event.id)} 
-                    isPreviewing={previewingEventIds.includes(event.id)} 
-                    allHotspots={allHotspots} 
+                {localHotspotEvents?.map((event, index) => (
+                  <EditableEventCard
+                    key={event.id}
+                    index={index}
+                    event={event}
+                    onUpdate={handleEventUpdate}
+                    onDelete={handleEventDelete}
+                    moveCard={moveEvent}
+                    onTogglePreview={() => handleTogglePreview(event.id)}
+                    onEdit={() => setEditingEvent(event)}
+                    isPreviewing={previewingEventIds.includes(event.id)}
+                    allHotspots={allHotspots}
                   />
-                )}
+                ))}
               </div>
             </div>
           </div>
+          )}
+          {editingEvent && editingEvent.type === InteractionType.PLAY_AUDIO && (
+            <MobilePlayAudioEditor
+              event={editingEvent}
+              onUpdate={(updatedEvent) => {
+                handleEventUpdate(updatedEvent);
+                setEditingEvent(null);
+              }}
+              onClose={() => setEditingEvent(null)}
+            />
           )}
         </div>
       </div>

--- a/src/client/components/HotspotEditorModal.tsx
+++ b/src/client/components/HotspotEditorModal.tsx
@@ -119,13 +119,16 @@ const EnhancedHotspotEditorModal: React.FC<EnhancedHotspotEditorModalProps> = ({
   onPreviewOverlay,
   onCollapseChange
 }) => {
+  const eventIdCounter = useRef(0);
+  const timestampCounter = useRef(0);
+
   // Debug logging to understand modal rendering
   console.log('🔍 HOTSPOT EDITOR MODAL DEBUG:', {
     isOpen,
     selectedHotspot: selectedHotspot ? { id: selectedHotspot.id, title: selectedHotspot.title } : null,
     relatedEventsCount: relatedEvents.length,
     component: 'HotspotEditorModal',
-    timestamp: Date.now()
+    timestamp: ++timestampCounter.current
   });
   // Local state for the hotspot being edited
   const [localHotspot, setLocalHotspot] = useState(selectedHotspot);
@@ -164,7 +167,7 @@ const EnhancedHotspotEditorModal: React.FC<EnhancedHotspotEditorModalProps> = ({
     if (!localHotspot) return;
     
     const newEvent: TimelineEventData = { 
-      id: `event_${Date.now()}`, 
+      id: `event_${++eventIdCounter.current}`, 
       name: `New ${type.toLowerCase().replace('_', ' ')} event`,
       step: currentStep,
       type,
@@ -301,7 +304,7 @@ const EnhancedHotspotEditorModal: React.FC<EnhancedHotspotEditorModalProps> = ({
     localHotspot: localHotspot ? { id: localHotspot.id, title: localHotspot.title } : null,
     selectedHotspot: selectedHotspot ? { id: selectedHotspot.id, title: selectedHotspot.title } : null,
     willReturn: (!isOpen || !localHotspot),
-    timestamp: Date.now()
+    timestamp: ++timestampCounter.current
   });
 
   if (!isOpen || !localHotspot) {
@@ -319,7 +322,7 @@ const EnhancedHotspotEditorModal: React.FC<EnhancedHotspotEditorModalProps> = ({
     isOpen,
     localHotspot: localHotspot ? { id: localHotspot.id, title: localHotspot.title } : null,
     className: `fixed top-0 right-0 z-60 h-screen transform transition-transform duration-300 ease-out ${isOpen ? 'translate-x-0' : 'translate-x-full'}`,
-    timestamp: Date.now()
+    timestamp: ++timestampCounter.current
   });
 
   return (

--- a/src/client/components/MobilePlayAudioEditor.tsx
+++ b/src/client/components/MobilePlayAudioEditor.tsx
@@ -1,0 +1,224 @@
+import React, { useState } from 'react';
+import { TimelineEventData, InteractionType, MediaQuizTrigger } from '../../shared/types';
+import { PlusIcon } from './icons/PlusIcon';
+import { TrashIcon } from './icons/TrashIcon';
+
+interface MobilePlayAudioEditorProps {
+  event: TimelineEventData;
+  onUpdate: (event: TimelineEventData) => void;
+  onClose: () => void;
+}
+
+const MobilePlayAudioEditor: React.FC<MobilePlayAudioEditorProps> = ({ event, onUpdate, onClose }) => {
+  const [internalEvent, setInternalEvent] = useState<TimelineEventData>(event);
+
+  const handleUpdate = (field: keyof TimelineEventData, value: any) => {
+    setInternalEvent(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handleQuizChange = (index: number, field: keyof MediaQuizTrigger, value: any) => {
+    const newQuizTriggers = [...(internalEvent.quizTriggers || [])];
+    newQuizTriggers[index] = { ...newQuizTriggers[index], [field]: value };
+    handleUpdate('quizTriggers', newQuizTriggers);
+  };
+
+  const addQuizQuestion = () => {
+    const newQuestion: MediaQuizTrigger = {
+      id: `quiz_${Date.now()}`,
+      timestamp: 0,
+      pauseMedia: true,
+      quiz: {
+        question: '',
+        options: ['', ''],
+        correctAnswer: 0,
+      },
+      resumeAfterCompletion: true,
+    };
+    handleUpdate('quizTriggers', [...(internalEvent.quizTriggers || []), newQuestion]);
+  };
+
+  const removeQuizQuestion = (index: number) => {
+    const newQuizTriggers = [...(internalEvent.quizTriggers || [])];
+    newQuizTriggers.splice(index, 1);
+    handleUpdate('quizTriggers', newQuizTriggers);
+  };
+
+  const handleSave = () => {
+    onUpdate(internalEvent);
+    onClose();
+  };
+
+  return (
+    <div className="p-4 bg-gray-800 text-white">
+      <h3 className="text-lg font-bold mb-4">Play Audio Event</h3>
+
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium">Audio Source</label>
+          <div className="flex space-x-2 mt-1">
+            <button className="flex-1 py-2 px-4 bg-blue-600 rounded">Upload Audio</button>
+            <button className="flex-1 py-2 px-4 bg-blue-600 rounded">Record</button>
+          </div>
+          <input
+            type="text"
+            placeholder="Or paste audio URL"
+            className="w-full mt-2 p-2 bg-gray-700 rounded"
+            value={internalEvent.audioUrl || ''}
+            onChange={(e) => handleUpdate('audioUrl', e.target.value)}
+          />
+        </div>
+
+        <div className="flex items-center justify-between">
+          <label>Auto start playback</label>
+          <input
+            type="checkbox"
+            checked={internalEvent.autoplay || false}
+            onChange={(e) => handleUpdate('autoplay', e.target.checked)}
+          />
+        </div>
+
+        <div className="flex items-center justify-between">
+          <label>Show player controls</label>
+          <input
+            type="checkbox"
+            checked={internalEvent.audioShowControls || false}
+            onChange={(e) => handleUpdate('audioShowControls', e.target.checked)}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium">Start at (seconds)</label>
+            <input
+              type="number"
+              placeholder="0"
+              className="w-full mt-1 p-2 bg-gray-700 rounded"
+              value={internalEvent.audioStartTime || ''}
+              onChange={(e) => handleUpdate('audioStartTime', parseInt(e.target.value))}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">End at (seconds)</label>
+            <input
+              type="number"
+              placeholder="End of audio"
+              className="w-full mt-1 p-2 bg-gray-700 rounded"
+              value={internalEvent.audioEndTime || ''}
+              onChange={(e) => handleUpdate('audioEndTime', parseInt(e.target.value))}
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <label>Include quiz questions</label>
+          <input
+            type="checkbox"
+            checked={!!internalEvent.quizTriggers}
+            onChange={(e) => handleUpdate('quizTriggers', e.target.checked ? [] : undefined)}
+          />
+        </div>
+
+        {internalEvent.quizTriggers && (
+          <div className="space-y-4 p-4 bg-gray-700 rounded">
+            {internalEvent.quizTriggers.map((quiz, index) => (
+              <div key={quiz.id} className="p-2 border border-gray-600 rounded">
+                <div className="flex items-center justify-between">
+                  <h4 className="font-bold">Question {index + 1}</h4>
+                  <button onClick={() => removeQuizQuestion(index)} className="p-1 text-red-500">
+                    <TrashIcon className="w-5 h-5" />
+                  </button>
+                </div>
+                <div className="space-y-2 mt-2">
+                  <input
+                    type="number"
+                    placeholder="Timestamp (seconds)"
+                    className="w-full p-2 bg-gray-600 rounded"
+                    value={quiz.timestamp}
+                    onChange={(e) => handleQuizChange(index, 'timestamp', parseInt(e.target.value))}
+                  />
+                  <select
+                    className="w-full p-2 bg-gray-600 rounded"
+                    value={quiz.quiz.questionType || 'multiple-choice'}
+                    onChange={(e) => handleQuizChange(index, 'quiz', { ...quiz.quiz, questionType: e.target.value })}
+                  >
+                    <option value="multiple-choice">Multiple Choice</option>
+                    <option value="fill-in-the-blank">Fill in the Blank</option>
+                  </select>
+                  <input
+                    type="text"
+                    placeholder="Question"
+                    className="w-full p-2 bg-gray-600 rounded"
+                    value={quiz.quiz.question}
+                    onChange={(e) => handleQuizChange(index, 'quiz', { ...quiz.quiz, question: e.target.value })}
+                  />
+                  {quiz.quiz.questionType === 'multiple-choice' && (
+                    <div className="space-y-2">
+                      {quiz.quiz.options.map((option, optionIndex) => (
+                        <div key={optionIndex} className="flex items-center space-x-2">
+                          <input
+                            type="checkbox"
+                            checked={quiz.quiz.correctAnswer === optionIndex}
+                            onChange={() => handleQuizChange(index, 'quiz', { ...quiz.quiz, correctAnswer: optionIndex })}
+                          />
+                          <input
+                            type="text"
+                            placeholder={`Option ${optionIndex + 1}`}
+                            className="flex-1 p-2 bg-gray-500 rounded"
+                            value={option}
+                            onChange={(e) => {
+                              const newOptions = [...quiz.quiz.options];
+                              newOptions[optionIndex] = e.target.value;
+                              handleQuizChange(index, 'quiz', { ...quiz.quiz, options: newOptions });
+                            }}
+                          />
+                        </div>
+                      ))}
+                      <button
+                        onClick={() => {
+                          const newOptions = [...quiz.quiz.options, ''];
+                          handleQuizChange(index, 'quiz', { ...quiz.quiz, options: newOptions });
+                        }}
+                        className="text-blue-400 text-sm"
+                      >
+                        Add another option
+                      </button>
+                    </div>
+                  )}
+                  <div className="flex items-center justify-between">
+                    <label className="text-sm">Show correct answer</label>
+                    <input
+                      type="checkbox"
+                      checked={quiz.quiz.showExplanation || false}
+                      onChange={(e) => handleQuizChange(index, 'quiz', { ...quiz.quiz, showExplanation: e.target.checked })}
+                    />
+                  </div>
+                  {quiz.quiz.questionType === 'fill-in-the-blank' && (
+                    <input
+                      type="text"
+                      placeholder="Correct Answer"
+                      className="w-full p-2 bg-gray-500 rounded"
+                      value={quiz.quiz.correctAnswer}
+                      onChange={(e) => handleQuizChange(index, 'quiz', { ...quiz.quiz, correctAnswer: e.target.value })}
+                    />
+                  )}
+                </div>
+              </div>
+            ))}
+            <button onClick={addQuizQuestion} className="w-full py-2 px-4 bg-blue-600 rounded flex items-center justify-center">
+              <PlusIcon className="w-5 h-5 mr-2" />
+              Add another question
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div className="mt-6">
+        <button onClick={handleSave} className="w-full py-3 px-4 bg-green-600 rounded text-white font-bold">
+          Save and close
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default MobilePlayAudioEditor;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -165,6 +165,8 @@ export interface TimelineEventData {
   audioUrl?: string;
   audioDisplayMode?: 'background' | 'modal' | 'mini-player';
   audioShowControls?: boolean;
+  audioStartTime?: number;
+  audioEndTime?: number;
   audioTitle?: string;
   audioArtist?: string;
   autoStartPlayback?: boolean;


### PR DESCRIPTION
This commit introduces the mobile hotspot editor settings for the "Play Audio" event type.

It includes the following features:
- A new `MobilePlayAudioEditor` component to manage audio event settings.
- UI elements for showing player controls, uploading/recording/linking audio, and setting start/end times.
- A toggle to auto-start audio playback.
- A quiz option, consistent with the video event settings.

The `HotspotEditorModal` has been updated to render the new audio editor when appropriate, and the `EditableEventCard` now triggers the editor for audio events.