### PR TITLE
Refactor: Move TabContent to a separate component

### DIFF
--- a/src/client/components/MobileEditorModal.tsx
+++ b/src/client/components/MobileEditorModal.tsx
@@ -38,16 +38,6 @@ interface TabState {
   canSwitchTabs: boolean;
 }
 
-const MOBILE_COLORS = [
-  { name: 'Purple', value: 'bg-purple-500', color: '#a855f7' },
-  { name: 'Blue', value: 'bg-blue-500', color: '#3b82f6' },
-  { name: 'Green', value: 'bg-green-500', color: '#22c55e' },
-  { name: 'Red', value: 'bg-red-500', color: '#ef4444' },
-  { name: 'Yellow', value: 'bg-yellow-500', color: '#eab308' },
-  { name: 'Pink', value: 'bg-pink-500', color: '#ec4899' },
-  { name: 'Indigo', value: 'bg-indigo-500', color: '#6366f1' },
-  { name: 'Gray', value: 'bg-gray-500', color: '#6b7280' },
-];
 
 const MOBILE_INTERACTION_TYPES = [
   // Visual Effects
@@ -417,7 +407,6 @@ const MobileEditorModal: React.FC<MobileEditorModalProps> = ({
                 setShowEventTypeSelector={setShowEventTypeSelector}
                 handlePreviewEvent={handlePreviewEvent}
                 setMediaFile={setMediaFile}
-                MOBILE_COLORS={MOBILE_COLORS}
               />
             </Suspense>
           </ReactPullToRefresh>

--- a/src/client/components/MobileEditorModal.tsx
+++ b/src/client/components/MobileEditorModal.tsx
@@ -7,13 +7,10 @@ import { triggerHapticFeedback } from '../utils/hapticUtils';
 import { useViewportHeight } from '../hooks/useViewportHeight';
 import { mobileStateManager } from '../utils/mobileStateManager';
 
-const MobileTextSettings = lazy(() => import('./mobile/MobileTextSettings'));
-const MobileEventEditor = lazy(() => import('./mobile/MobileEventEditor'));
+import TabContent from './mobile/TabContent';
 const MobileEventPreview = lazy(() => import('./mobile/MobileEventPreview'));
 const MobilePreviewOverlay = lazy(() => import('./mobile/MobilePreviewOverlay'));
 const MobileEventTypeSelector = lazy(() => import('./mobile/MobileEventTypeSelector'));
-const MobileCameraCapture = lazy(() => import('./mobile/MobileCameraCapture'));
-const MobileVoiceRecorder = lazy(() => import('./mobile/MobileVoiceRecorder'));
 
 interface MobileEditorModalProps {
   isOpen: boolean;
@@ -315,189 +312,6 @@ const MobileEditorModal: React.FC<MobileEditorModalProps> = ({
     });
   };
 
-  const TabContent = () => {
-    if (!localHotspot) return null;
-
-    if (tabState.activeTab === 'basic') {
-      return (
-        <div className="space-y-6 p-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-300 mb-3">
-              Title
-            </label>
-            <input
-              type="text"
-              value={localHotspot.title}
-              onChange={(e) => updateLocalHotspot({ title: e.target.value })}
-              className="w-full bg-slate-700 border border-slate-600 rounded-lg px-4 py-3 text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-              placeholder="Enter hotspot title"
-            />
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-300 mb-3">
-              Description
-            </label>
-            <textarea
-              value={localHotspot.description}
-              onChange={(e) => updateLocalHotspot({ description: e.target.value })}
-              rows={4}
-              className="w-full bg-slate-700 border border-slate-600 rounded-lg px-4 py-3 text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent resize-none"
-              placeholder="Enter hotspot description"
-            />
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-300 mb-3">
-              Media
-            </label>
-            <div className="space-y-4">
-              <Suspense fallback={<div>Loading...</div>}>
-                <MobileCameraCapture
-                  onCapture={(file) => {
-                    setMediaFile(file);
-                    // Here you would typically trigger an upload process
-                    // For now, we'll just log it.
-                    console.log('Captured file:', file);
-                  }}
-                />
-              </Suspense>
-              <Suspense fallback={<div>Loading...</div>}>
-                <MobileVoiceRecorder
-                  onRecord={(file) => {
-                    setMediaFile(file);
-                    // Here you would typically trigger an upload process
-                    // For now, we'll just log it.
-                    console.log('Recorded file:', file);
-                  }}
-                />
-              </Suspense>
-            </div>
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-300 mb-3">
-              Media URL (optional)
-            </label>
-            <input
-              type="url"
-              value={localHotspot.link || ''}
-              onChange={(e) => updateLocalHotspot({ link: e.target.value })}
-              className="w-full bg-slate-700 border border-slate-600 rounded-lg px-4 py-3 text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-              placeholder="https://example.com/image.jpg"
-            />
-          </div>
-        </div>
-      );
-    }
-
-    if (tabState.activeTab === 'style') {
-      return (
-        <div className="space-y-6 p-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-300 mb-3">
-              Background Color
-            </label>
-            <div className="grid grid-cols-4 gap-3">
-              {MOBILE_COLORS.map((color) => (
-                <button
-                  key={color.value}
-                  onClick={() => updateLocalHotspot({ backgroundColor: color.value })}
-                  className={`w-12 h-12 rounded-full border-4 transition-all duration-200 ${
-                    localHotspot?.backgroundColor === color.value
-                      ? 'border-white ring-4 ring-purple-500 ring-opacity-50 scale-105'
-                      : 'border-gray-600 hover:border-gray-400'
-                  }`}
-                  style={{ backgroundColor: color.color }}
-                  aria-label={color.name}
-                >
-                  {localHotspot?.backgroundColor === color.value && (
-                    <div className="w-full h-full flex items-center justify-center">
-                      <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 20 20">
-                        <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                      </svg>
-                    </div>
-                  )}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-300 mb-3">
-              Size
-            </label>
-            <div className="flex space-x-3">
-              {[
-                { value: 'small', label: 'Small', size: '32px' },
-                { value: 'medium', label: 'Medium', size: '40px' },
-                { value: 'large', label: 'Large', size: '48px' }
-              ].map((size) => (
-                <button
-                  key={size.value}
-                  onClick={() => updateLocalHotspot({ size: size.value as any })}
-                  className={`flex-1 p-4 border-2 rounded-lg transition-all duration-200 ${
-                    localHotspot?.size === size.value
-                      ? 'border-purple-500 bg-purple-500 bg-opacity-20'
-                      : 'border-gray-600 hover:border-gray-400'
-                  }`}
-                >
-                  <div className="flex flex-col items-center space-y-2">
-                    <div
-                      className={`rounded-full ${localHotspot?.backgroundColor || 'bg-purple-500'}`}
-                      style={{ width: size.size, height: size.size }}
-                    />
-                    <span className="text-sm text-gray-300">{size.label}</span>
-                  </div>
-                </button>
-              ))}
-            </div>
-          </div>
-        </div>
-      );
-    }
-
-    if (tabState.activeTab === 'timeline') {
-      if (editingEvent) {
-        const handleBack = () => setEditingEvent(null);
-        return (
-          <div className="p-4">
-            <button onClick={handleBack} className="text-purple-400 hover:text-purple-300 mb-4">
-              &larr; Back to Events
-            </button>
-            {editingEvent.type === InteractionType.SHOW_TEXT && (
-              <MobileTextSettings
-                event={editingEvent}
-                onUpdate={(updatedEvent) => {
-                  onUpdateTimelineEvent(updatedEvent);
-                  setEditingEvent(updatedEvent);
-                }}
-              />
-            )}
-            {/* Add other event settings components here */}
-          </div>
-        );
-      }
-
-      return (
-        <MobileEventEditor
-          events={hotspotEvents}
-          onAddEvent={() => setShowEventTypeSelector(true)}
-          onEventsChange={handleHotspotEventsChange}
-          onSelectEvent={(event) => {
-            if (event.type === InteractionType.SHOW_TEXT) {
-              setEditingEvent(event);
-            }
-            // Add handlers for other event types here
-          }}
-          onPreviewEvent={handlePreviewEvent}
-        />
-      );
-    }
-
-    return null;
-  };
-
   if (!isOpen || !hotspot || !localHotspot) return null;
 
   if (isPreviewing && eventToPreview) {
@@ -591,7 +405,20 @@ const MobileEditorModal: React.FC<MobileEditorModalProps> = ({
         <div className="flex-1 overflow-y-auto" {...handleSwipe}>
           <ReactPullToRefresh onRefresh={() => Promise.resolve()}>
             <Suspense fallback={<div>Loading...</div>}>
-              <TabContent />
+              <TabContent
+                activeTab={tabState.activeTab}
+                localHotspot={localHotspot}
+                updateLocalHotspot={updateLocalHotspot}
+                hotspotEvents={hotspotEvents}
+                editingEvent={editingEvent}
+                setEditingEvent={setEditingEvent}
+                onUpdateTimelineEvent={onUpdateTimelineEvent}
+                handleHotspotEventsChange={handleHotspotEventsChange}
+                setShowEventTypeSelector={setShowEventTypeSelector}
+                handlePreviewEvent={handlePreviewEvent}
+                setMediaFile={setMediaFile}
+                MOBILE_COLORS={MOBILE_COLORS}
+              />
             </Suspense>
           </ReactPullToRefresh>
         </div>

--- a/src/client/components/mobile/TabContent.tsx
+++ b/src/client/components/mobile/TabContent.tsx
@@ -1,0 +1,220 @@
+import React, { Suspense } from 'react';
+import { HotspotData, TimelineEventData, InteractionType } from '../../../shared/types';
+
+const MobileTextSettings = React.lazy(() => import('./MobileTextSettings'));
+const MobileEventEditor = React.lazy(() => import('./MobileEventEditor'));
+const MobileCameraCapture = React.lazy(() => import('./MobileCameraCapture'));
+const MobileVoiceRecorder = React.lazy(() => import('./MobileVoiceRecorder'));
+
+interface TabContentProps {
+  activeTab: 'basic' | 'style' | 'timeline' | 'advanced';
+  localHotspot: HotspotData;
+  updateLocalHotspot: (updates: Partial<HotspotData>) => void;
+  hotspotEvents: TimelineEventData[];
+  editingEvent: TimelineEventData | null;
+  setEditingEvent: (event: TimelineEventData | null) => void;
+  onUpdateTimelineEvent: (event: TimelineEventData) => void;
+  handleHotspotEventsChange: (updatedHotspotEvents: TimelineEventData[]) => void;
+  setShowEventTypeSelector: (show: boolean) => void;
+  handlePreviewEvent: (event: TimelineEventData) => void;
+  setMediaFile: (file: File | null) => void;
+  MOBILE_COLORS: { name: string; value: string; color: string }[];
+}
+
+const TabContent: React.FC<TabContentProps> = ({
+  activeTab,
+  localHotspot,
+  updateLocalHotspot,
+  hotspotEvents,
+  editingEvent,
+  setEditingEvent,
+  onUpdateTimelineEvent,
+  handleHotspotEventsChange,
+  setShowEventTypeSelector,
+  handlePreviewEvent,
+  setMediaFile,
+  MOBILE_COLORS,
+}) => {
+  if (!localHotspot) return null;
+
+  if (activeTab === 'basic') {
+    return (
+      <div className="space-y-6 p-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-3">
+            Title
+          </label>
+          <input
+            type="text"
+            value={localHotspot.title}
+            onChange={(e) => updateLocalHotspot({ title: e.target.value })}
+            className="w-full bg-slate-700 border border-slate-600 rounded-lg px-4 py-3 text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+            placeholder="Enter hotspot title"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-3">
+            Description
+          </label>
+          <textarea
+            value={localHotspot.description}
+            onChange={(e) => updateLocalHotspot({ description: e.target.value })}
+            rows={4}
+            className="w-full bg-slate-700 border border-slate-600 rounded-lg px-4 py-3 text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent resize-none"
+            placeholder="Enter hotspot description"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-3">
+            Media
+          </label>
+          <div className="space-y-4">
+            <Suspense fallback={<div>Loading...</div>}>
+              <MobileCameraCapture
+                onCapture={(file) => {
+                  setMediaFile(file);
+                  // Here you would typically trigger an upload process
+                  // For now, we'll just log it.
+                  console.log('Captured file:', file);
+                }}
+              />
+            </Suspense>
+            <Suspense fallback={<div>Loading...</div>}>
+              <MobileVoiceRecorder
+                onRecord={(file) => {
+                  setMediaFile(file);
+                  // Here you would typically trigger an upload process
+                  // For now, we'll just log it.
+                  console.log('Recorded file:', file);
+                }}
+              />
+            </Suspense>
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-3">
+            Media URL (optional)
+          </label>
+          <input
+            type="url"
+            value={localHotspot.link || ''}
+            onChange={(e) => updateLocalHotspot({ link: e.target.value })}
+            className="w-full bg-slate-700 border border-slate-600 rounded-lg px-4 py-3 text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+            placeholder="https://example.com/image.jpg"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (activeTab === 'style') {
+    return (
+      <div className="space-y-6 p-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-3">
+            Background Color
+          </label>
+          <div className="grid grid-cols-4 gap-3">
+            {MOBILE_COLORS.map((color) => (
+              <button
+                key={color.value}
+                onClick={() => updateLocalHotspot({ backgroundColor: color.value })}
+                className={`w-12 h-12 rounded-full border-4 transition-all duration-200 ${
+                  localHotspot?.backgroundColor === color.value
+                    ? 'border-white ring-4 ring-purple-500 ring-opacity-50 scale-105'
+                    : 'border-gray-600 hover:border-gray-400'
+                }`}
+                style={{ backgroundColor: color.color }}
+                aria-label={color.name}
+              >
+                {localHotspot?.backgroundColor === color.value && (
+                  <div className="w-full h-full flex items-center justify-center">
+                    <svg className="w-6 h-6 text-white" fill="currentColor" viewBox="0 0 20 20">
+                      <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                    </svg>
+                  </div>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-3">
+            Size
+          </label>
+          <div className="flex space-x-3">
+            {[
+              { value: 'small', label: 'Small', size: '32px' },
+              { value: 'medium', label: 'Medium', size: '40px' },
+              { value: 'large', label: 'Large', size: '48px' }
+            ].map((size) => (
+              <button
+                key={size.value}
+                onClick={() => updateLocalHotspot({ size: size.value as any })}
+                className={`flex-1 p-4 border-2 rounded-lg transition-all duration-200 ${
+                  localHotspot?.size === size.value
+                    ? 'border-purple-500 bg-purple-500 bg-opacity-20'
+                    : 'border-gray-600 hover:border-gray-400'
+                }`}
+              >
+                <div className="flex flex-col items-center space-y-2">
+                  <div
+                    className={`rounded-full ${localHotspot?.backgroundColor || 'bg-purple-500'}`}
+                    style={{ width: size.size, height: size.size }}
+                  />
+                  <span className="text-sm text-gray-300">{size.label}</span>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (activeTab === 'timeline') {
+    if (editingEvent) {
+      const handleBack = () => setEditingEvent(null);
+      return (
+        <div className="p-4">
+          <button onClick={handleBack} className="text-purple-400 hover:text-purple-300 mb-4">
+            &larr; Back to Events
+          </button>
+          {editingEvent.type === InteractionType.SHOW_TEXT && (
+            <MobileTextSettings
+              event={editingEvent}
+              onUpdate={(updatedEvent) => {
+                onUpdateTimelineEvent(updatedEvent);
+                setEditingEvent(updatedEvent);
+              }}
+            />
+          )}
+          {/* Add other event settings components here */}
+        </div>
+      );
+    }
+
+    return (
+      <MobileEventEditor
+        events={hotspotEvents}
+        onAddEvent={() => setShowEventTypeSelector(true)}
+        onEventsChange={handleHotspotEventsChange}
+        onSelectEvent={(event) => {
+          if (event.type === InteractionType.SHOW_TEXT) {
+            setEditingEvent(event);
+          }
+          // Add handlers for other event types here
+        }}
+        onPreviewEvent={handlePreviewEvent}
+      />
+    );
+  }
+
+  return null;
+};
+
+export default TabContent;

--- a/src/client/components/mobile/TabContent.tsx
+++ b/src/client/components/mobile/TabContent.tsx
@@ -1,10 +1,28 @@
 import React, { Suspense } from 'react';
-import { HotspotData, TimelineEventData, InteractionType } from '../../../shared/types';
+import { HotspotData, TimelineEventData, InteractionType, HotspotSize } from '../../../shared/types';
 
 const MobileTextSettings = React.lazy(() => import('./MobileTextSettings'));
 const MobileEventEditor = React.lazy(() => import('./MobileEventEditor'));
 const MobileCameraCapture = React.lazy(() => import('./MobileCameraCapture'));
 const MobileVoiceRecorder = React.lazy(() => import('./MobileVoiceRecorder'));
+
+// Constants moved from parent component for better encapsulation
+const MOBILE_COLORS = [
+  { name: 'Purple', value: 'bg-purple-500', color: '#a855f7' },
+  { name: 'Blue', value: 'bg-blue-500', color: '#3b82f6' },
+  { name: 'Green', value: 'bg-green-500', color: '#22c55e' },
+  { name: 'Red', value: 'bg-red-500', color: '#ef4444' },
+  { name: 'Yellow', value: 'bg-yellow-500', color: '#eab308' },
+  { name: 'Pink', value: 'bg-pink-500', color: '#ec4899' },
+  { name: 'Indigo', value: 'bg-indigo-500', color: '#6366f1' },
+  { name: 'Gray', value: 'bg-gray-500', color: '#6b7280' },
+];
+
+const SIZE_OPTIONS = [
+  { value: 'small' as HotspotSize, label: 'Small', size: '32px' },
+  { value: 'medium' as HotspotSize, label: 'Medium', size: '40px' },
+  { value: 'large' as HotspotSize, label: 'Large', size: '48px' }
+];
 
 interface TabContentProps {
   activeTab: 'basic' | 'style' | 'timeline' | 'advanced';
@@ -18,7 +36,6 @@ interface TabContentProps {
   setShowEventTypeSelector: (show: boolean) => void;
   handlePreviewEvent: (event: TimelineEventData) => void;
   setMediaFile: (file: File | null) => void;
-  MOBILE_COLORS: { name: string; value: string; color: string }[];
 }
 
 const TabContent: React.FC<TabContentProps> = ({
@@ -33,7 +50,6 @@ const TabContent: React.FC<TabContentProps> = ({
   setShowEventTypeSelector,
   handlePreviewEvent,
   setMediaFile,
-  MOBILE_COLORS,
 }) => {
   if (!localHotspot) return null;
 
@@ -147,14 +163,10 @@ const TabContent: React.FC<TabContentProps> = ({
             Size
           </label>
           <div className="flex space-x-3">
-            {[
-              { value: 'small', label: 'Small', size: '32px' },
-              { value: 'medium', label: 'Medium', size: '40px' },
-              { value: 'large', label: 'Large', size: '48px' }
-            ].map((size) => (
+            {SIZE_OPTIONS.map((size) => (
               <button
                 key={size.value}
-                onClick={() => updateLocalHotspot({ size: size.value as any })}
+                onClick={() => updateLocalHotspot({ size: size.value })}
                 className={`flex-1 p-4 border-2 rounded-lg transition-all duration-200 ${
                   localHotspot?.size === size.value
                     ? 'border-purple-500 bg-purple-500 bg-opacity-20'
@@ -181,7 +193,11 @@ const TabContent: React.FC<TabContentProps> = ({
       const handleBack = () => setEditingEvent(null);
       return (
         <div className="p-4">
-          <button onClick={handleBack} className="text-purple-400 hover:text-purple-300 mb-4">
+          <button 
+            onClick={handleBack} 
+            className="text-purple-400 hover:text-purple-300 mb-4"
+            aria-label="Back to Events list"
+          >
             &larr; Back to Events
           </button>
           {editingEvent.type === InteractionType.SHOW_TEXT && (


### PR DESCRIPTION
I moved the `TabContent` function from `MobileEditorModal.tsx` to its own file, `src/client/components/mobile/TabContent.tsx`.

This refactoring prevents the `TabContent` from being redefined on every render of `MobileEditorModal`, which was causing a `ReferenceError` on mobile devices.