### PR TITLE
feat: Add settings button to mobile hotspot events

### DIFF
--- a/src/client/components/MobileHotspotEditor.tsx
+++ b/src/client/components/MobileHotspotEditor.tsx
@@ -373,51 +373,16 @@ const MobileHotspotEditor: React.FC<MobileHotspotEditorProps> = ({
                     {event.name || `Event at step ${event.step}`}
                   </span>
                   <div>
-                    {event.type === InteractionType.PLAY_AUDIO && (
-                        <button
-                            onClick={() => setEditingEvent(event)}
-                            className="text-purple-400 hover:text-purple-300 p-1"
-                            aria-label="Edit event"
-                        >
-                            Edit
-                        </button>
-                    )}
-                    {event.type === InteractionType.PLAY_VIDEO && (
-                      <button
-                        onClick={() => setEditingEvent(event)}
-                        className="text-blue-400 hover:text-blue-300 p-1"
-                        aria-label="Edit event"
-                      >
-                        Edit
-                      </button>
-                    )}
-                    {event.type === InteractionType.QUIZ && (
-                      <button
-                        onClick={() => setEditingEvent(event)}
-                        className="text-yellow-400 hover:text-yellow-300 p-1"
-                        aria-label="Edit event"
-                      >
-                        Edit
-                      </button>
-                    )}
-                    {event.type === InteractionType.PAN_ZOOM_TO_HOTSPOT && (
-                      <button
-                        onClick={() => setEditingEvent(event)}
-                        className="text-green-400 hover:text-green-300 p-1"
-                        aria-label="Edit event"
-                      >
-                        Edit
-                      </button>
-                    )}
-                    {event.type === InteractionType.SHOW_TEXT && (
-                      <button
-                        onClick={() => setEditingEvent(event)}
-                        className="text-blue-400 hover:text-blue-300 p-1"
-                        aria-label="Edit event"
-                      >
-                        Edit
-                      </button>
-                    )}
+                    <button
+                      onClick={() => setEditingEvent(event)}
+                      className="text-purple-400 hover:text-purple-300 p-1"
+                      aria-label="Edit event"
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                      </svg>
+                    </button>
                     <button
                       onClick={() => onDeleteTimelineEvent(event.id)}
                       className="text-red-400 hover:text-red-300 p-1"


### PR DESCRIPTION
This commit adds a settings button to each hotspot event in the mobile hotspot editor. This allows you to open the settings panel and adjust all of the event settings after creating the event.