### PR TITLE
Fix(mobile): Prevent pan&zoom repeat on next step

### DIFF
--- a/src/client/components/InteractiveViewer.tsx
+++ b/src/client/components/InteractiveViewer.tsx
@@ -174,17 +174,37 @@ const InteractiveViewer: React.FC<InteractiveViewerProps> = ({
 
   const handlePrevStep = useCallback(() => {
     if (currentStepIndex > 0) {
-      resetTransform();
-      setCurrentStep(uniqueSortedSteps[currentStepIndex - 1]);
+      const prevStepIndex = currentStepIndex - 1;
+      const prevStep = uniqueSortedSteps[prevStepIndex];
+      const eventsForPrevStep = timelineEvents.filter(event => event.step === prevStep);
+      const hasPanZoom = eventsForPrevStep.some(event =>
+        event.type === InteractionType.PAN_ZOOM || event.type === InteractionType.PAN_ZOOM_TO_HOTSPOT
+      );
+
+      if (!hasPanZoom) {
+        resetTransform();
+      }
+
+      setCurrentStep(prevStep);
     }
-  }, [currentStepIndex, uniqueSortedSteps, resetTransform]);
+  }, [currentStepIndex, uniqueSortedSteps, timelineEvents, resetTransform]);
 
   const handleNextStep = useCallback(() => {
     if (currentStepIndex < uniqueSortedSteps.length - 1) {
-      resetTransform();
-      setCurrentStep(uniqueSortedSteps[currentStepIndex + 1]);
+      const nextStepIndex = currentStepIndex + 1;
+      const nextStep = uniqueSortedSteps[nextStepIndex];
+      const eventsForNextStep = timelineEvents.filter(event => event.step === nextStep);
+      const hasPanZoom = eventsForNextStep.some(event =>
+        event.type === InteractionType.PAN_ZOOM || event.type === InteractionType.PAN_ZOOM_TO_HOTSPOT
+      );
+
+      if (!hasPanZoom) {
+        resetTransform();
+      }
+
+      setCurrentStep(nextStep);
     }
-  }, [currentStepIndex, uniqueSortedSteps, resetTransform]);
+  }, [currentStepIndex, uniqueSortedSteps, timelineEvents, resetTransform]);
 
   const handleMobileEventComplete = useCallback(() => {
     setMobileActiveEvents([]);

--- a/src/client/components/mobile/MobileEventRenderer.tsx
+++ b/src/client/components/mobile/MobileEventRenderer.tsx
@@ -259,20 +259,12 @@ export const MobileEventRenderer: React.FC<MobileEventRendererProps> = ({
 
     const handleTimelineNext = () => {
       if (canGoToNextStep && onNextStep) {
-        // Reset pan & zoom when moving to next step if currently active
-        if (activePanZoomEvent && onTransformUpdate) {
-          onTransformUpdate(createResetTransform());
-        }
         onNextStep();
       }
     };
 
     const handleTimelinePrevious = () => {
       if (canGoToPrevStep && onPrevStep) {
-        // Reset pan & zoom when moving to previous step if currently active
-        if (activePanZoomEvent && onTransformUpdate) {
-          onTransformUpdate(createResetTransform());
-        }
         onPrevStep();
       }
     };


### PR DESCRIPTION
This commit fixes a bug in the mobile viewer where a pan&zoom event would appear to repeat when you clicked the 'next' button.

The issue was caused by the `InteractiveViewer` component unconditionally resetting the image transform before advancing to the next step. This caused the view to reset to the default state before panning and zooming to the new location, creating a "repeating" effect.

The fix involves two changes:

1.  In `InteractiveViewer.tsx`, the `handleNextStep` and `handlePrevStep` functions now check if the upcoming step has a pan&zoom event. The transform is only reset if the next/previous step does not have a pan&zoom event.
2.  The redundant transform reset logic in `MobileEventRenderer.tsx` has been removed, as this is now handled by the `InteractiveViewer`.