### PR TITLE
feat: Add pulse animation settings for hotspots

### DIFF
--- a/src/client/components/HotspotEditorModal.tsx
+++ b/src/client/components/HotspotEditorModal.tsx
@@ -404,19 +404,31 @@ const EnhancedHotspotEditorModal: React.FC<EnhancedHotspotEditorModalProps> = ({
                 <label htmlFor="pulse-animation-toggle" className="text-sm text-gray-300">
                   Pulse Animation
                 </label>
-                <div
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={!!localHotspot.pulseAnimation}
                   onClick={() =>
-                    setLocalHotspot(prev => prev ? { ...prev, pulseAnimation: !prev.pulseAnimation } : null)
+                    setLocalHotspot(prev => {
+                      if (!prev) return null;
+                      const newPulseAnimation = !prev.pulseAnimation;
+                      return {
+                        ...prev,
+                        pulseAnimation: newPulseAnimation,
+                        // Set a default pulseType when enabling animation
+                        ...(newPulseAnimation && !prev.pulseType && { pulseType: 'loop' as const }),
+                      };
+                    })
                   }
                   id="pulse-animation-toggle"
-                  className={`relative inline-flex items-center h-6 rounded-full w-11 cursor-pointer transition-colors
+                  className={`relative inline-flex items-center h-6 rounded-full w-11 cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-800
                               ${localHotspot.pulseAnimation ? 'bg-green-500' : 'bg-gray-600'}`}
                 >
                   <span
                     className={`inline-block w-4 h-4 transform bg-white rounded-full transition-transform
                                 ${localHotspot.pulseAnimation ? 'translate-x-6' : 'translate-x-1'}`}
                   />
-                </div>
+                </button>
               </div>
               {/* Pulse Type Radio Buttons */}
               {localHotspot.pulseAnimation && (
@@ -459,11 +471,17 @@ const EnhancedHotspotEditorModal: React.FC<EnhancedHotspotEditorModalProps> = ({
                   <input
                     type="number"
                     id="pulse-duration"
-                    value={localHotspot.pulseDuration || ''}
-                    onChange={e =>
-                      setLocalHotspot(prev => prev ? { ...prev, pulseDuration: Number(e.target.value) } : null)
-                    }
+                    value={localHotspot.pulseDuration ?? ''}
+                    onChange={e => {
+                      const newDuration = parseFloat(e.target.value);
+                      setLocalHotspot(prev => 
+                        prev ? { ...prev, pulseDuration: isNaN(newDuration) ? undefined : newDuration } : null
+                      );
+                    }}
                     className="w-full bg-gray-600 border border-gray-500 rounded px-3 py-2 text-white mt-2"
+                    min="0"
+                    step="0.1"
+                    placeholder="Enter duration in seconds"
                   />
                 </div>
               )}

--- a/src/client/components/HotspotEditorModal.tsx
+++ b/src/client/components/HotspotEditorModal.tsx
@@ -399,6 +399,74 @@ const EnhancedHotspotEditorModal: React.FC<EnhancedHotspotEditorModalProps> = ({
                   />
                 </div>
               </div>
+              {/* Pulse Animation Toggle */}
+              <div className="flex items-center justify-between mt-4">
+                <label htmlFor="pulse-animation-toggle" className="text-sm text-gray-300">
+                  Pulse Animation
+                </label>
+                <div
+                  onClick={() =>
+                    setLocalHotspot(prev => prev ? { ...prev, pulseAnimation: !prev.pulseAnimation } : null)
+                  }
+                  id="pulse-animation-toggle"
+                  className={`relative inline-flex items-center h-6 rounded-full w-11 cursor-pointer transition-colors
+                              ${localHotspot.pulseAnimation ? 'bg-green-500' : 'bg-gray-600'}`}
+                >
+                  <span
+                    className={`inline-block w-4 h-4 transform bg-white rounded-full transition-transform
+                                ${localHotspot.pulseAnimation ? 'translate-x-6' : 'translate-x-1'}`}
+                  />
+                </div>
+              </div>
+              {/* Pulse Type Radio Buttons */}
+              {localHotspot.pulseAnimation && (
+                <div className="mt-4">
+                  <label className="text-sm text-gray-300">Pulse Type</label>
+                  <div className="flex items-center mt-2">
+                    <input
+                      type="radio"
+                      id="pulse-loop"
+                      name="pulseType"
+                      value="loop"
+                      checked={localHotspot.pulseType === 'loop'}
+                      onChange={() =>
+                        setLocalHotspot(prev => prev ? { ...prev, pulseType: 'loop' } : null)
+                      }
+                      className="mr-2"
+                    />
+                    <label htmlFor="pulse-loop" className="text-sm text-gray-300">Loop</label>
+                    <input
+                      type="radio"
+                      id="pulse-timed"
+                      name="pulseType"
+                      value="timed"
+                      checked={localHotspot.pulseType === 'timed'}
+                      onChange={() =>
+                        setLocalHotspot(prev => prev ? { ...prev, pulseType: 'timed' } : null)
+                      }
+                      className="ml-4 mr-2"
+                    />
+                    <label htmlFor="pulse-timed" className="text-sm text-gray-300">Timed</label>
+                  </div>
+                </div>
+              )}
+              {/* Pulse Duration Input */}
+              {localHotspot.pulseAnimation && localHotspot.pulseType === 'timed' && (
+                <div className="mt-4">
+                  <label htmlFor="pulse-duration" className="text-sm text-gray-300">
+                    Pulse Duration (seconds)
+                  </label>
+                  <input
+                    type="number"
+                    id="pulse-duration"
+                    value={localHotspot.pulseDuration || ''}
+                    onChange={e =>
+                      setLocalHotspot(prev => prev ? { ...prev, pulseDuration: Number(e.target.value) } : null)
+                    }
+                    className="w-full bg-gray-600 border border-gray-500 rounded px-3 py-2 text-white mt-2"
+                  />
+                </div>
+              )}
             </div>
 
             {/* Add Event Button - For adding events to the current hotspot */}

--- a/src/client/components/HotspotViewer.tsx
+++ b/src/client/components/HotspotViewer.tsx
@@ -354,11 +354,13 @@ const HotspotViewer: React.FC<HotspotViewerProps> = (props) => {
     }
   }, [hotspot.pulseAnimation, hotspot.pulseType, hotspot.pulseDuration]);
 
+  const shouldPulse = isContinuouslyPulsing || (hotspot.pulseAnimation && hotspot.pulseType === 'loop') || isTimedPulseActive;
+
   const dotClasses = `relative inline-flex items-center justify-center rounded-full ${sizeClasses} ${baseColor}
     transition-all duration-150 ease-in-out group-hover:brightness-110 group-focus:brightness-110
     focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-transparent ${ringColor}
     shadow-md hover:shadow-lg
-    ${isContinuouslyPulsing || (hotspot.pulseAnimation && hotspot.pulseType === 'loop') || isTimedPulseActive ? 'animate-pulse-subtle' : ''}
+    ${shouldPulse ? 'animate-pulse-subtle' : ''}
     ${isEditing && onPositionChange ? 'cursor-move' : 'cursor-pointer'}
     ${isDragging ? 'scale-110 shadow-xl z-50 brightness-125' : ''}
     ${isHolding ? 'scale-105 animate-pulse ring-2 ring-white/50' : ''}`;

--- a/src/client/components/HotspotViewer.tsx
+++ b/src/client/components/HotspotViewer.tsx
@@ -342,11 +342,23 @@ const HotspotViewer: React.FC<HotspotViewerProps> = (props) => {
 
   const sizeClasses = getSizeClasses(hotspot.size);
   
+  const [isTimedPulseActive, setIsTimedPulseActive] = useState(false);
+
+  useEffect(() => {
+    if (hotspot.pulseAnimation && hotspot.pulseType === 'timed' && hotspot.pulseDuration) {
+      setIsTimedPulseActive(true);
+      const timer = setTimeout(() => {
+        setIsTimedPulseActive(false);
+      }, hotspot.pulseDuration * 1000);
+      return () => clearTimeout(timer);
+    }
+  }, [hotspot.pulseAnimation, hotspot.pulseType, hotspot.pulseDuration]);
+
   const dotClasses = `relative inline-flex items-center justify-center rounded-full ${sizeClasses} ${baseColor}
     transition-all duration-150 ease-in-out group-hover:brightness-110 group-focus:brightness-110
     focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-transparent ${ringColor}
     shadow-md hover:shadow-lg
-    ${isContinuouslyPulsing ? 'animate-pulse-subtle' : ''}
+    ${isContinuouslyPulsing || (hotspot.pulseAnimation && hotspot.pulseType === 'loop') || isTimedPulseActive ? 'animate-pulse-subtle' : ''}
     ${isEditing && onPositionChange ? 'cursor-move' : 'cursor-pointer'}
     ${isDragging ? 'scale-110 shadow-xl z-50 brightness-125' : ''}
     ${isHolding ? 'scale-105 animate-pulse ring-2 ring-white/50' : ''}`;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -41,6 +41,9 @@ export interface HotspotData {
   link?: string; // Optional link URL for hotspot
   displayHotspotInEvent?: boolean; // When true, hotspot remains visible when its events are active
   pulseWhenActive?: boolean; // When true, hotspot pulses when its events are active
+  pulseAnimation?: boolean; // When true, pulse animation is enabled
+  pulseType?: 'loop' | 'timed'; // Type of pulse animation
+  pulseDuration?: number; // Duration of the pulse animation in seconds
 }
 
 // Base Event interface


### PR DESCRIPTION
This commit introduces new settings for hotspot pulse animations.

- Adds a toggle to enable or disable the pulse animation in the hotspot appearance menu.
- When the pulse animation is enabled, you can choose between a "loop" or "timed" animation.
- For timed animations, a text field is provided to enter the duration in seconds.
- In explore mode, all hotspots now have a subtle pulse to indicate they are clickable areas.