### PR TITLE
fix: Add default slideDeck to new projects

### DIFF
--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -20,7 +20,7 @@ import ViewerView from './views/ViewerView';
 import SlideBasedTestPage from './SlideBasedTestPage';
 import SlideEditorTestPage from './SlideEditorTestPage';
 import MigrationTestPage from './MigrationTestPage';
-import { setDynamicVhProperty } from '../utils/mobileUtils';
+import { createDefaultSlideDeck } from '../utils/slideDeckUtils';
 
 
 const LoadingScreen: React.FC = () => (
@@ -183,26 +183,7 @@ const MainApp: React.FC = () => {
       const projectWithSlideType = {
         ...newProject,
         projectType: 'slide' as const,
-        slideDeck: {
-          id: newProject.id,
-          title: newProject.title,
-          slides: [],
-          settings: {
-            autoAdvance: false,
-            allowNavigation: true,
-            showProgress: true,
-            showControls: true,
-            keyboardShortcuts: true,
-            touchGestures: true,
-            fullscreenMode: false,
-          },
-          metadata: {
-            created: Date.now(),
-            modified: Date.now(),
-            version: '1.0',
-            isPublic: false,
-          },
-        },
+        slideDeck: createDefaultSlideDeck(newProject.id, newProject.title),
       };
 
       // If demo data is provided, save it with the project

--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -182,7 +182,27 @@ const MainApp: React.FC = () => {
       // Set project type to 'slide' for new projects (this is the slides-based app)
       const projectWithSlideType = {
         ...newProject,
-        projectType: 'slide' as const
+        projectType: 'slide' as const,
+        slideDeck: {
+          id: newProject.id,
+          title: newProject.title,
+          slides: [],
+          settings: {
+            autoAdvance: false,
+            allowNavigation: true,
+            showProgress: true,
+            showControls: true,
+            keyboardShortcuts: true,
+            touchGestures: true,
+            fullscreenMode: false,
+          },
+          metadata: {
+            created: Date.now(),
+            modified: Date.now(),
+            version: '1.0',
+            isPublic: false,
+          },
+        },
       };
 
       // If demo data is provided, save it with the project


### PR DESCRIPTION
When creating a new project, the `projectType` was being set to 'slide' but no `slideDeck` object was being created. This caused a validation error when the project was saved.

This change adds a default `slideDeck` object to new projects, which fixes the validation error and allows new projects to be created successfully.