### PR TITLE
fix(constraints): Add toolbar and header heights to useLayoutConstraints

### DIFF
--- a/src/client/hooks/useLayoutConstraints.ts
+++ b/src/client/hooks/useLayoutConstraints.ts
@@ -54,6 +54,10 @@ export interface LayoutConstraints {
   isMobile: boolean;
   layoutMode: 'compact' | 'standard' | 'expanded';
   orientation: 'portrait' | 'landscape';
+
+  // Key UI element dimensions
+  toolbarHeight: number;
+  headerHeight: number;
 }
 
 export interface ModalConstraintOptions {
@@ -79,6 +83,10 @@ export function useLayoutConstraints(options: ModalConstraintOptions = {}): Layo
   const { deviceType, viewportInfo, isMobile } = useDeviceDetection();
   const { height: viewportHeight, availableHeight } = useViewportHeight();
 
+  // Define key UI element heights for consistent calculations
+  const headerHeight = isMobile ? 44 : 0; // Represents mobile status bar area
+  const toolbarHeight = preventToolbarOverlap ? (deviceType === 'mobile' ? 56 : 64) : 0;
+
   // Calculate safe area boundaries based on device type and viewport
   const safeArea = useMemo(() => {
     // Base safe area from CSS env() variables or defaults
@@ -91,19 +99,15 @@ export function useLayoutConstraints(options: ModalConstraintOptions = {}): Layo
 
     // Add device-specific safe areas
     if (isMobile) {
-      // Mobile devices need safe area insets
-      base.top = 44; // Status bar + safe area
+      base.top = headerHeight; // Status bar + safe area
       base.bottom = 34; // Home indicator safe area
     }
 
-    if (preventToolbarOverlap) {
-      // Standard toolbar heights by device type
-      const toolbarHeight = deviceType === 'mobile' ? 56 : 64;
-      base.bottom += toolbarHeight;
-    }
+    // Account for toolbar height if overlap prevention is on
+    base.bottom += toolbarHeight;
 
     return base;
-  }, [deviceType, isMobile, preventToolbarOverlap]);
+  }, [isMobile, headerHeight, toolbarHeight]);
 
   // Calculate modal constraints based on safe area
   const modal = useMemo(() => {
@@ -234,6 +238,8 @@ export function useLayoutConstraints(options: ModalConstraintOptions = {}): Layo
     isMobile,
     layoutMode: deviceType === 'mobile' ? 'compact' : deviceType === 'tablet' ? 'standard' : 'expanded',
     orientation: viewportInfo.orientation,
+    toolbarHeight,
+    headerHeight,
   };
 }
 

--- a/src/tests/coreFunctionality/UnifiedSlideEditor.test.tsx
+++ b/src/tests/coreFunctionality/UnifiedSlideEditor.test.tsx
@@ -29,7 +29,13 @@ vi.mock('../../client/hooks/useToast', async () => {
 });
 
 vi.mock('../../client/hooks/useDeviceDetection', () => ({
-  useDeviceDetection: () => ({ isMobile: false, deviceType: 'desktop', isTablet: false, isDesktop: true }),
+  useDeviceDetection: () => ({
+    isMobile: false,
+    deviceType: 'desktop',
+    isTablet: false,
+    isDesktop: true,
+    viewportInfo: { width: 1920, height: 1080, orientation: 'landscape' },
+  }),
 }));
 
 vi.mock('../../lib/firebaseApi', () => ({


### PR DESCRIPTION
The `useLayoutConstraints` hook was not exposing the `toolbarHeight` and `headerHeight` values it used in its internal calculations. This caused a crash in components like `MobilePropertiesPanel` that tried to access `constraints.toolbarHeight`.

This change refactors the `useLayoutConstraints` hook to:
1.  Add `toolbarHeight` and `headerHeight` to the `LayoutConstraints` interface.
2.  Calculate and return these values in the hook's output object.

Additionally, this change updates a failing test suite (`UnifiedSlideEditor.test.tsx`) by providing a complete mock for the `useDeviceDetection` hook, which now includes the `viewportInfo` object required by the updated constraints hook in a test environment.