### PR TITLE
fix(canvas): Pass onSlideUpdate prop correctly

### DIFF
--- a/src/client/components/slides/ResponsiveCanvas.tsx
+++ b/src/client/components/slides/ResponsiveCanvas.tsx
@@ -648,7 +648,7 @@ export const ResponsiveCanvas: React.FC<ResponsiveCanvasProps> = ({
           currentSlide={currentSlide}
           deviceType={deviceType}
           onElementUpdate={(updates) => handleElementUpdate(selectedElement.id, updates)}
-          onSlideUpdate={handleSlideUpdate}
+          onSlideUpdate={onSlideUpdate}
           onDelete={() => {
             // Remove element from slide
             const updatedSlideDeck = {


### PR DESCRIPTION
In `ResponsiveCanvas.tsx`, the `UnifiedPropertiesPanel` was being passed a prop `onSlideUpdate` with a value of `handleSlideUpdate`, which was not defined in the component. This caused a `ReferenceError`.

The intention was to pass the `onSlideUpdate` function that is received as a prop by `ResponsiveCanvas`.

This commit fixes the `ReferenceError` by passing the correct `onSlideUpdate` prop to the `UnifiedPropertiesPanel` component.