### PR TITLE
I've fixed a batch of TypeScript errors based on the list in `typescr…

### DIFF
--- a/src/client/components/HotspotEditorToolbar.tsx
+++ b/src/client/components/HotspotEditorToolbar.tsx
@@ -336,6 +336,10 @@ const HotspotEditorToolbar: React.FC<HotspotEditorToolbarProps> = ({
                   onUpdate={handleUpdateEvent}
                   onDelete={handleDeleteEvent}
                   onJumpToStep={onJumpToStep}
+                  onEdit={() => {
+                    // No-op for this deprecated component.
+                    // The modern editor handles this with a modal.
+                  }}
                   moveCard={() => {}} // TODO: Implement proper drag and drop
                   onTogglePreview={() => {}} // TODO: Implement preview functionality
                   isPreviewing={false}

--- a/src/client/components/HotspotViewer.tsx
+++ b/src/client/components/HotspotViewer.tsx
@@ -359,12 +359,11 @@ const HotspotViewer: React.FC<HotspotViewerProps> = (props) => {
   const getCustomStyles = () => {
     const styles: React.CSSProperties = {};
     
-    // Apply opacity from multiple sources (priority: customProperties -> hotspot.opacity)
+    // Apply opacity from customProperties, which may be passed for slide-based elements
     const customOpacity = (hotspot as any).customProperties?.opacity;
-    const opacity = customOpacity !== undefined ? customOpacity : hotspot.opacity;
     
-    if (opacity !== undefined) {
-      styles.opacity = opacity;
+    if (customOpacity !== undefined) {
+      styles.opacity = customOpacity;
     }
     
     return styles;

--- a/src/client/components/slides/effects/TextEffectSettings.tsx
+++ b/src/client/components/slides/effects/TextEffectSettings.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback, useState } from 'react';
-import { SlideEffect, ShowTextParameters } from '../../../../shared/slideTypes';
+import { SlideEffect, ShowTextParameters, TextStyle } from '../../../../shared/slideTypes';
 
 interface TextEffectSettingsProps {
   effect: SlideEffect;
@@ -28,6 +28,15 @@ export const TextEffectSettings: React.FC<TextEffectSettingsProps> = ({
       }
     });
   }, [parameters, onUpdate]);
+
+  const handleStyleUpdate = useCallback((styleUpdates: Partial<TextStyle>) => {
+    handleParameterUpdate({
+      style: {
+        ...parameters.style,
+        ...styleUpdates
+      }
+    });
+  }, [parameters, handleParameterUpdate]);
 
   const handleTextBlur = useCallback(() => {
     handleParameterUpdate({ text: textContent });
@@ -100,12 +109,12 @@ export const TextEffectSettings: React.FC<TextEffectSettingsProps> = ({
             type="range"
             min="10"
             max="48"
-            value={parameters.fontSize || 16}
-            onChange={(e) => handleParameterUpdate({ fontSize: parseInt(e.target.value) })}
+            value={parameters.style?.fontSize || 16}
+            onChange={(e) => handleStyleUpdate({ fontSize: parseInt(e.target.value) })}
             className="flex-1"
           />
           <span className="text-xs text-slate-400 w-12">
-            {parameters.fontSize || 16}px
+            {parameters.style?.fontSize || 16}px
           </span>
         </div>
       </div>
@@ -119,9 +128,9 @@ export const TextEffectSettings: React.FC<TextEffectSettingsProps> = ({
           {['left', 'center', 'right'].map((align) => (
             <button
               key={align}
-              onClick={() => handleParameterUpdate({ textAlign: align as any })}
+              onClick={() => handleStyleUpdate({ textAlign: align as any })}
               className={`p-2 rounded border text-xs font-medium transition-colors ${
-                (parameters.textAlign || 'center') === align
+                (parameters.style?.textAlign || 'center') === align
                   ? 'bg-purple-600 border-purple-500 text-white'
                   : 'bg-slate-700 border-slate-600 text-slate-300 hover:bg-slate-600'
               }`}
@@ -227,14 +236,14 @@ export const TextEffectSettings: React.FC<TextEffectSettingsProps> = ({
           <div className="flex items-center gap-2">
             <input
               type="color"
-              value={parameters.backgroundColor || '#1e293b'}
-              onChange={(e) => handleParameterUpdate({ backgroundColor: e.target.value })}
+              value={parameters.style?.backgroundColor || '#1e293b'}
+              onChange={(e) => handleStyleUpdate({ backgroundColor: e.target.value })}
               className="w-8 h-8 rounded border border-slate-600 cursor-pointer"
             />
             <input
               type="text"
-              value={parameters.backgroundColor || '#1e293b'}
-              onChange={(e) => handleParameterUpdate({ backgroundColor: e.target.value })}
+              value={parameters.style?.backgroundColor || '#1e293b'}
+              onChange={(e) => handleStyleUpdate({ backgroundColor: e.target.value })}
               className="flex-1 bg-slate-700 border border-slate-600 rounded px-2 py-1 text-white text-xs"
               placeholder="#1e293b"
             />
@@ -248,12 +257,12 @@ export const TextEffectSettings: React.FC<TextEffectSettingsProps> = ({
                 min="0"
                 max="1"
                 step="0.1"
-                value={parameters.backgroundOpacity || 0.9}
-                onChange={(e) => handleParameterUpdate({ backgroundOpacity: parseFloat(e.target.value) })}
+                value={parameters.style?.backgroundOpacity || 0.9}
+                onChange={(e) => handleStyleUpdate({ backgroundOpacity: parseFloat(e.target.value) })}
                 className="flex-1"
               />
               <span className="text-xs text-slate-400 w-12">
-                {Math.round((parameters.backgroundOpacity || 0.9) * 100)}%
+                {Math.round((parameters.style?.backgroundOpacity || 0.9) * 100)}%
               </span>
             </div>
           </div>

--- a/src/client/components/slides/effects/TextEffectSettings.tsx
+++ b/src/client/components/slides/effects/TextEffectSettings.tsx
@@ -89,7 +89,7 @@ export const TextEffectSettings: React.FC<TextEffectSettingsProps> = ({
         </label>
         <select
           value={parameters.displayMode || 'modal'}
-          onChange={(e) => handleParameterUpdate({ displayMode: e.target.value as any })}
+          onChange={(e) => handleParameterUpdate({ displayMode: e.target.value as 'modal' | 'tooltip' | 'banner' | 'overlay' })}
           className="w-full bg-slate-700 border border-slate-600 rounded px-2 py-1 text-white text-xs"
         >
           <option value="modal">Modal</option>
@@ -125,10 +125,10 @@ export const TextEffectSettings: React.FC<TextEffectSettingsProps> = ({
           Text Alignment
         </label>
         <div className="grid grid-cols-3 gap-2">
-          {['left', 'center', 'right'].map((align) => (
+          {(['left', 'center', 'right'] as const).map((align) => (
             <button
               key={align}
-              onClick={() => handleStyleUpdate({ textAlign: align as any })}
+              onClick={() => handleStyleUpdate({ textAlign: align })}
               className={`p-2 rounded border text-xs font-medium transition-colors ${
                 (parameters.style?.textAlign || 'center') === align
                   ? 'bg-purple-600 border-purple-500 text-white'
@@ -180,7 +180,7 @@ export const TextEffectSettings: React.FC<TextEffectSettingsProps> = ({
             </label>
             <select
               value={parameters.modalPosition || 'center'}
-              onChange={(e) => handleParameterUpdate({ modalPosition: e.target.value as any })}
+              onChange={(e) => handleParameterUpdate({ modalPosition: e.target.value as 'center' | 'top' | 'bottom' | 'left' | 'right' | 'element' })}
               className="w-full bg-slate-700 border border-slate-600 rounded px-2 py-1 text-white text-xs"
             >
               <option value="center">Center</option>

--- a/src/shared/slideTypes.ts
+++ b/src/shared/slideTypes.ts
@@ -232,6 +232,12 @@ export interface ShowTextParameters {
   position: FixedPosition;
   style: TextStyle;
   displayDuration?: number;
+  displayMode?: 'modal' | 'tooltip' | 'banner' | 'overlay';
+  modalWidth?: number;
+  modalMaxHeight?: number;
+  modalPosition?: 'center' | 'top' | 'bottom' | 'left' | 'right' | 'element';
+  autoClose?: boolean;
+  autoCloseDuration?: number;
 }
 
 export interface PlayMediaParameters {
@@ -301,6 +307,7 @@ export interface TextStyle {
   fontWeight?: 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';
   color: string;
   backgroundColor?: string;
+  backgroundOpacity?: number;
   padding?: number;
   borderRadius?: number;
   textAlign?: 'left' | 'center' | 'right';

--- a/typescript_errors.md
+++ b/typescript_errors.md
@@ -1,8 +1,8 @@
 # TypeScript Errors Report
 
 **Generated:** 2025-08-04  
-**Total Errors:** 409 → ~390 (Critical and High Priority Fixed)  
-**Status:** Improved - Critical and high priority errors resolved
+**Total Errors:** 409 → ~362 (Medium Priority Fixes)
+**Status:** In Progress - Medium priority errors being addressed
 
 ## Executive Summary
 
@@ -41,18 +41,21 @@ This codebase has **409 TypeScript errors** that are currently not being caught 
 *These errors indicate interface mismatches that may cause subtle bugs*
 
 #### Hotspot and Element Property Issues
-**File:** `src/client/components/HotspotViewer.tsx`
+✅ **File:** `src/client/components/HotspotViewer.tsx`
 - **Line:** 364
 - **Issue:** Property `opacity` does not exist on `HotspotData`
 - **Impact:** Visual hotspot rendering issues
+- **Fix:** Removed incorrect fallback to `hotspot.opacity`. Opacity is now correctly sourced from `customProperties`.
 
-**File:** `src/client/components/HotspotEditorToolbar.tsx`
+✅ **File:** `src/client/components/HotspotEditorToolbar.tsx`
 - **Line:** 331
 - **Issue:** Missing `onEdit` property in `EditableEventCardProps`
 - **Impact:** Hotspot editing functionality incomplete
+- **Fix:** Passed a no-op function for the `onEdit` prop to satisfy the type requirement in the deprecated component.
 
 #### Effects and Interaction Components
-**File:** `src/client/components/slides/effects/TextEffectSettings.tsx` (26 errors)
+✅ **File:** `src/client/components/slides/effects/TextEffectSettings.tsx` (26 errors)
+- **Fix:** Corrected all 26 errors by updating the `ShowTextParameters` and `TextStyle` interfaces and refactoring the component to access nested style properties correctly.
 **File:** `src/client/components/slides/effects/QuizEffectSettings.tsx` (21 errors)
 **File:** `src/client/components/slides/effects/SpotlightEffectSettings.tsx` (17 errors)
 **File:** `src/client/components/slides/effects/MediaEffectSettings.tsx` (16 errors)


### PR DESCRIPTION
…ipt_errors.md`. Here's a breakdown of the changes I made:

- `src/client/components/HotspotViewer.tsx`: Fixed an error where `hotspot.opacity` was being accessed on a type where it doesn't exist.
- `src/client/components/HotspotEditorToolbar.tsx`: Fixed a missing `onEdit` prop on a deprecated component by passing a no-op function.
- `src/client/components/slides/effects/TextEffectSettings.tsx`: Fixed 26 errors by updating the `ShowTextParameters` and `TextStyle` interfaces in `slideTypes.ts` and refactoring the component to handle nested style properties correctly.

I've also updated the `typescript_errors.md` file to reflect these fixes.