### PR TITLE
fix: remove unnecessary return statements after reject() calls in Pro…

### DIFF
--- a/src/lib/firebaseApi.ts
+++ b/src/lib/firebaseApi.ts
@@ -901,12 +901,10 @@ export class FirebaseProjectAPI {
         currentUser = this.getCurrentUser();
       } catch (error) {
         reject(error);
-        return;
       }
 
       if (!file || file.size === 0) {
         reject(new Error('Invalid file: File is empty or corrupted'));
-        return;
       }
 
       const timestamp = Date.now();


### PR DESCRIPTION
…mise executor

Addresses Copilot code review feedback about inconsistent Promise executor patterns:
- Removed return statement after reject(error) at line 903
- Removed return statement after reject(new Error(''Invalid file...'')) at line 907

In Promise executors, reject() calls should be the final action for error paths without requiring explicit return statements.