### PR TITLE
feat: Implement interaction property editors in hotspot modal

### DIFF
--- a/src/client/components/HotspotEditorModal.tsx
+++ b/src/client/components/HotspotEditorModal.tsx
@@ -17,6 +17,9 @@ import { TrashIcon } from './icons/TrashIcon';
 import { XMarkIcon } from './icons/XMarkIcon';
 import InteractionSettingsModal from './InteractionSettingsModal';
 import InteractionTypeSelector, { AddInteractionButton } from './InteractionTypeSelector';
+import PanZoomSettings from './PanZoomSettings';
+import { PlusIcon } from './icons/PlusIcon';
+import SpotlightSettings from './SpotlightSettings';
 import TabContainer from './ui/TabContainer';
 
 interface EnhancedHotspotEditorModalProps {
@@ -77,6 +80,391 @@ const HotspotEditorToolbar: React.FC<{
 );
 
 HotspotEditorToolbar.displayName = 'HotspotEditorToolbar';
+
+const inputClasses = "w-full bg-gray-700 p-2 rounded border border-gray-600 focus:ring-purple-500 focus:border-purple-500";
+const labelClasses = "block text-sm font-medium text-gray-300 mb-1";
+
+interface InteractionEditorProps {
+  event: TimelineEventData;
+  onUpdate: (updates: Partial<TimelineEventData>) => void;
+}
+
+const TextInteractionEditor: React.FC<InteractionEditorProps> = React.memo(({ event, onUpdate }) => {
+    return (
+        <div className="space-y-4">
+            <div>
+                <label htmlFor="textContent" className={labelClasses}>Text Content</label>
+                <textarea
+                    id="textContent"
+                    value={event.textContent || ''}
+                    onChange={e => onUpdate({ textContent: e.target.value })}
+                    className={`${inputClasses} min-h-[80px]`}
+                    rows={4}
+                />
+            </div>
+            <div>
+                <label htmlFor="textPosition" className={labelClasses}>Position</label>
+                <select
+                    id="textPosition"
+                    value={event.textPosition || 'center'}
+                    onChange={e => onUpdate({ textPosition: e.target.value as 'center' | 'custom' })}
+                    className={inputClasses}
+                >
+                    <option value="center">Center</option>
+                    <option value="custom">Custom</option>
+                </select>
+            </div>
+            {event.textPosition === 'custom' && (
+                <div className="grid grid-cols-2 gap-4">
+                    <div>
+                        <label htmlFor="textX" className={labelClasses}>X (%)</label>
+                        <input
+                            id="textX"
+                            type="number"
+                            value={event.textX || 50}
+                            onChange={e => onUpdate({ textX: parseInt(e.target.value, 10) })}
+                            className={inputClasses}
+                        />
+                    </div>
+                    <div>
+                        <label htmlFor="textY" className={labelClasses}>Y (%)</label>
+                        <input
+                            id="textY"
+                            type="number"
+                            value={event.textY || 50}
+                            onChange={e => onUpdate({ textY: parseInt(e.target.value, 10) })}
+                            className={inputClasses}
+                        />
+                    </div>
+                </div>
+            )}
+            <div className="grid grid-cols-2 gap-4">
+                <div>
+                    <label htmlFor="textWidth" className={labelClasses}>Width (px)</label>
+                    <input
+                        id="textWidth"
+                        type="number"
+                        value={event.textWidth || 300}
+                        onChange={e => onUpdate({ textWidth: parseInt(e.target.value, 10) })}
+                        className={inputClasses}
+                    />
+                </div>
+                <div>
+                    <label htmlFor="textHeight" className={labelClasses}>Height (px)</label>
+                    <input
+                        id="textHeight"
+                        type="number"
+                        value={event.textHeight || 100}
+                        onChange={e => onUpdate({ textHeight: parseInt(e.target.value, 10) })}
+                        className={inputClasses}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+});
+TextInteractionEditor.displayName = 'TextInteractionEditor';
+
+const AudioInteractionEditor: React.FC<InteractionEditorProps> = React.memo(({ event, onUpdate }) => {
+    const checkboxLabelClasses = "flex items-center space-x-2 cursor-pointer text-sm text-gray-300";
+    const checkboxInputClasses = "form-checkbox h-4 w-4 text-purple-600 bg-slate-600 border-slate-500 rounded focus:ring-purple-500";
+
+    return (
+        <div className="space-y-4">
+            <div>
+                <label htmlFor="audioUrl" className={labelClasses}>Audio URL</label>
+                <input
+                    id="audioUrl"
+                    type="text"
+                    value={event.audioUrl || ''}
+                    onChange={e => onUpdate({ audioUrl: e.target.value })}
+                    className={inputClasses}
+                    placeholder="https://example.com/audio.mp3"
+                />
+            </div>
+            <div>
+                <label htmlFor="audioDisplayMode" className={labelClasses}>Display Mode</label>
+                <select
+                    id="audioDisplayMode"
+                    value={event.audioDisplayMode || 'background'}
+                    onChange={e => onUpdate({ audioDisplayMode: e.target.value as 'background' | 'modal' | 'mini-player' })}
+                    className={inputClasses}
+                >
+                    <option value="background">Background</option>
+                    <option value="modal">Modal</option>
+                    <option value="mini-player">Mini-Player</option>
+                </select>
+            </div>
+            <div>
+                <label htmlFor="volume" className={labelClasses}>Volume</label>
+                <input
+                    id="volume"
+                    type="range"
+                    min="0"
+                    max="100"
+                    value={event.volume === undefined ? 80 : event.volume}
+                    onChange={e => onUpdate({ volume: parseInt(e.target.value, 10) })}
+                    className="w-full"
+                />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+                <label className={checkboxLabelClasses}>
+                    <input
+                        type="checkbox"
+                        checked={!!event.audioShowControls}
+                        onChange={e => onUpdate({ audioShowControls: e.target.checked })}
+                        className={checkboxInputClasses}
+                    />
+                    <span>Show Controls</span>
+                </label>
+                <label className={checkboxLabelClasses}>
+                    <input
+                        type="checkbox"
+                        checked={!!event.autoplay}
+                        onChange={e => onUpdate({ autoplay: e.target.checked })}
+                        className={checkboxInputClasses}
+                    />
+                    <span>Autoplay</span>
+                </label>
+                <label className={checkboxLabelClasses}>
+                    <input
+                        type="checkbox"
+                        checked={!!event.loop}
+                        onChange={e => onUpdate({ loop: e.target.checked })}
+                        className={checkboxInputClasses}
+                    />
+                    <span>Loop</span>
+                </label>
+            </div>
+        </div>
+    );
+});
+AudioInteractionEditor.displayName = 'AudioInteractionEditor';
+
+const VideoInteractionEditor: React.FC<InteractionEditorProps> = React.memo(({ event, onUpdate }) => {
+    const checkboxLabelClasses = "flex items-center space-x-2 cursor-pointer text-sm text-gray-300";
+    const checkboxInputClasses = "form-checkbox h-4 w-4 text-purple-600 bg-slate-600 border-slate-500 rounded focus:ring-purple-500";
+
+    const isYouTube = event.videoSource === 'youtube';
+
+    return (
+        <div className="space-y-4">
+            <div>
+                <label htmlFor="videoSource" className={labelClasses}>Video Source</label>
+                <select
+                    id="videoSource"
+                    value={event.videoSource || 'url'}
+                    onChange={e => {
+                        const newSource = e.target.value as 'url' | 'youtube';
+                        onUpdate({ videoSource: newSource, videoUrl: '', youtubeVideoId: '' });
+                    }}
+                    className={inputClasses}
+                >
+                    <option value="url">URL</option>
+                    <option value="youtube">YouTube</option>
+                </select>
+            </div>
+
+            {isYouTube ? (
+                <div>
+                    <label htmlFor="youtubeVideoId" className={labelClasses}>YouTube Video ID</label>
+                    <input
+                        id="youtubeVideoId"
+                        type="text"
+                        value={event.youtubeVideoId || ''}
+                        onChange={e => onUpdate({ youtubeVideoId: e.target.value })}
+                        className={inputClasses}
+                        placeholder="e.g. dQw4w9WgXcQ"
+                    />
+                </div>
+            ) : (
+                <div>
+                    <label htmlFor="videoUrl" className={labelClasses}>Video URL</label>
+                    <input
+                        id="videoUrl"
+                        type="text"
+                        value={event.videoUrl || ''}
+                        onChange={e => onUpdate({ videoUrl: e.target.value })}
+                        className={inputClasses}
+                        placeholder="https://example.com/video.mp4"
+                    />
+                </div>
+            )}
+
+            <div>
+                <label htmlFor="videoDisplayMode" className={labelClasses}>Display Mode</label>
+                <select
+                    id="videoDisplayMode"
+                    value={event.videoDisplayMode || 'inline'}
+                    onChange={e => onUpdate({ videoDisplayMode: e.target.value as 'inline' | 'modal' | 'overlay' })}
+                    className={inputClasses}
+                >
+                    <option value="inline">Inline</option>
+                    <option value="modal">Modal</option>
+                    <option value="overlay">Overlay</option>
+                </select>
+            </div>
+
+            {isYouTube && (
+                <div className="grid grid-cols-2 gap-4">
+                    <div>
+                        <label htmlFor="youtubeStartTime" className={labelClasses}>Start Time (s)</label>
+                        <input
+                            id="youtubeStartTime"
+                            type="number"
+                            value={event.youtubeStartTime || ''}
+                            onChange={e => {
+                              const startTimeValue = e.target.value;
+                              if (startTimeValue) {
+                                const numValue = parseInt(startTimeValue, 10);
+                                if (!isNaN(numValue)) {
+                                  onUpdate({ youtubeStartTime: numValue });
+                                }
+                              } else {
+                                onUpdate({ youtubeStartTime: null });
+                              }
+                            }}
+                            className={inputClasses}
+                        />
+                    </div>
+                    <div>
+                        <label htmlFor="youtubeEndTime" className={labelClasses}>End Time (s)</label>
+                        <input
+                            id="youtubeEndTime"
+                            type="number"
+                            value={event.youtubeEndTime || ''}
+                            onChange={e => {
+                              const endTimeValue = e.target.value;
+                              if (endTimeValue) {
+                                const numValue = parseInt(endTimeValue, 10);
+                                if (!isNaN(numValue)) {
+                                  onUpdate({ youtubeEndTime: numValue });
+                                }
+                              } else {
+                                onUpdate({ youtubeEndTime: null });
+                              }
+                            }}
+                            className={inputClasses}
+                        />
+                    </div>
+                </div>
+            )}
+
+            <div className="grid grid-cols-2 gap-4">
+                <label className={checkboxLabelClasses}>
+                    <input
+                        type="checkbox"
+                        checked={!!event.videoShowControls}
+                        onChange={e => onUpdate({ videoShowControls: e.target.checked })}
+                        className={checkboxInputClasses}
+                    />
+                    <span>Show Controls</span>
+                </label>
+                <label className={checkboxLabelClasses}>
+                    <input
+                        type="checkbox"
+                        checked={!!event.autoplay}
+                        onChange={e => onUpdate({ autoplay: e.target.checked })}
+                        className={checkboxInputClasses}
+                    />
+                    <span>Autoplay</span>
+                </label>
+                <label className={checkboxLabelClasses}>
+                    <input
+                        type="checkbox"
+                        checked={!!event.loop}
+                        onChange={e => onUpdate({ loop: e.target.checked })}
+                        className={checkboxInputClasses}
+                    />
+                    <span>Loop</span>
+                </label>
+            </div>
+        </div>
+    );
+});
+VideoInteractionEditor.displayName = 'VideoInteractionEditor';
+
+const QuizInteractionEditor: React.FC<InteractionEditorProps> = React.memo(({ event, onUpdate }) => {
+    const handleOptionChange = (index: number, value: string) => {
+        const newOptions = [...(event.quizOptions || [])];
+        newOptions[index] = value;
+        onUpdate({ quizOptions: newOptions });
+    };
+
+    const handleAddOption = () => {
+        const newOptions = [...(event.quizOptions || []), `New Option ${(event.quizOptions?.length || 0) + 1}`];
+        onUpdate({ quizOptions: newOptions });
+    };
+
+    const handleDeleteOption = (index: number) => {
+        const newOptions = [...(event.quizOptions || [])];
+        newOptions.splice(index, 1);
+        onUpdate({ quizOptions: newOptions });
+    };
+
+    const handleCorrectAnswerChange = (index: number) => {
+        onUpdate({ quizCorrectAnswer: index });
+    };
+
+    return (
+        <div className="space-y-4">
+            <div>
+                <label htmlFor="quizQuestion" className={labelClasses}>Question</label>
+                <input
+                    id="quizQuestion"
+                    type="text"
+                    value={event.quizQuestion || ''}
+                    onChange={e => onUpdate({ quizQuestion: e.target.value })}
+                    className={inputClasses}
+                />
+            </div>
+
+            <div>
+                <label className={labelClasses}>Options</label>
+                <div className="space-y-2">
+                    {(event.quizOptions || []).map((option, index) => (
+                        <div key={`quiz-option-${index}-${option.length}-${option.charAt(0) || 'empty'}-${option.slice(-3)}`} className="flex items-center space-x-2">
+                            <input
+                                type="radio"
+                                name="correctAnswer"
+                                checked={event.quizCorrectAnswer === index}
+                                onChange={() => handleCorrectAnswerChange(index)}
+                                className="form-radio h-4 w-4 text-purple-600 bg-slate-600 border-slate-500"
+                            />
+                            <input
+                                type="text"
+                                value={option}
+                                onChange={e => handleOptionChange(index, e.target.value)}
+                                className={inputClasses}
+                            />
+                            <button onClick={() => handleDeleteOption(index)} className="p-1 text-red-500 hover:text-red-400">
+                                <TrashIcon className="w-4 h-4" />
+                            </button>
+                        </div>
+                    ))}
+                </div>
+                <button onClick={handleAddOption} className="mt-2 text-sm text-purple-400 hover:text-purple-300 flex items-center">
+                    <PlusIcon className="w-4 h-4 mr-1" />
+                    Add Option
+                </button>
+            </div>
+
+            <div>
+                <label htmlFor="quizExplanation" className={labelClasses}>Explanation (optional)</label>
+                <textarea
+                    id="quizExplanation"
+                    value={event.quizExplanation || ''}
+                    onChange={e => onUpdate({ quizExplanation: e.target.value })}
+                    className={`${inputClasses} min-h-[60px]`}
+                    rows={3}
+                    placeholder="Explain why the correct answer is right."
+                />
+            </div>
+        </div>
+    );
+});
+QuizInteractionEditor.displayName = 'QuizInteractionEditor';
+
 
 const HotspotEditorModal: React.FC<EnhancedHotspotEditorModalProps> = ({
   editorState,
@@ -199,6 +587,49 @@ const HotspotEditorModal: React.FC<EnhancedHotspotEditorModalProps> = ({
 
   const handleEventUpdate = (updatedEvent: TimelineEventData) => {
     onUpdateEvent(updatedEvent);
+  };
+
+  const handlePartialEventUpdate = (updates: Partial<TimelineEventData>) => {
+    const { editingEventId } = editorState.interactionEditor;
+    const event = relatedEvents.find((e) => e.id === editingEventId);
+    if (event) {
+      onUpdateEvent({ ...event, ...updates });
+    }
+  };
+
+  const renderEditorForEvent = (event: TimelineEventData) => {
+    switch (event.type) {
+      case InteractionType.PAN_ZOOM:
+        return (
+          <PanZoomSettings
+            zoomLevel={event.zoomLevel || 2}
+            onZoomChange={(zoom) => handlePartialEventUpdate({ zoomLevel: zoom })}
+            showTextBanner={!!event.showTextBanner}
+            onShowTextBannerChange={(value) => handlePartialEventUpdate({ showTextBanner: value })}
+          />
+        );
+      case InteractionType.SPOTLIGHT:
+        return (
+          <SpotlightSettings
+            shape={event.spotlightShape || 'circle'}
+            onShapeChange={(shape) => handlePartialEventUpdate({ spotlightShape: shape })}
+            dimPercentage={event.backgroundDimPercentage || 70}
+            onDimPercentageChange={(dim) => handlePartialEventUpdate({ backgroundDimPercentage: dim })}
+            showTextBanner={event.showTextBanner || false}
+            onShowTextBannerChange={(value) => handlePartialEventUpdate({ showTextBanner: value })}
+          />
+        );
+      case InteractionType.TEXT:
+        return <TextInteractionEditor event={event} onUpdate={handlePartialEventUpdate} />;
+      case InteractionType.AUDIO:
+        return <AudioInteractionEditor event={event} onUpdate={handlePartialEventUpdate} />;
+      case InteractionType.VIDEO:
+        return <VideoInteractionEditor event={event} onUpdate={handlePartialEventUpdate} />;
+      case InteractionType.QUIZ:
+        return <QuizInteractionEditor event={event} onUpdate={handlePartialEventUpdate} />;
+      default:
+        return <div className="text-center py-4 text-gray-400">No specific editor available for this interaction type.</div>;
+    }
   };
 
   const handleEventDelete = (eventId: string) => {
@@ -566,18 +997,26 @@ const HotspotEditorModal: React.FC<EnhancedHotspotEditorModalProps> = ({
                     id: 'properties',
                     label: 'Properties',
                     content: (
-                      <div className="p-4">
+                      <div className="p-4 overflow-y-auto h-full">
                         {editingEventId ? (
-                          <div className="text-gray-300">
-                            <h3 className="text-lg font-semibold mb-4">Event Properties</h3>
-                            <p className="text-sm text-gray-400 mb-4">
-                              Editing properties for event: {relatedEvents.find((e) => e.id === editingEventId)?.name || 'Unknown'}
-                            </p>
-                            {/* Properties content will be moved here from InteractionSettingsModal */}
-                            <div className="bg-gray-700 p-4 rounded-lg">
-                              <p className="text-sm">Properties editor integration coming soon...</p>
-                            </div>
-                          </div>
+                          (() => {
+                            const event = relatedEvents.find((e) => e.id === editingEventId);
+                            if (!event) {
+                              return (
+                                <div className="text-center text-gray-400 py-8">
+                                  Could not find the selected event.
+                                </div>
+                              );
+                            }
+                            return (
+                              <div className="text-gray-300">
+                                <h3 className="text-lg font-semibold mb-4">
+                                  Edit: {event.name}
+                                </h3>
+                                {renderEditorForEvent(event)}
+                              </div>
+                            );
+                          })()
                         ) : (
                           <div className="text-center text-gray-400 py-8">
                             Select an interaction from the Interactions tab to edit its properties.
@@ -591,12 +1030,6 @@ const HotspotEditorModal: React.FC<EnhancedHotspotEditorModalProps> = ({
             </div>
           </div>
         </div>
-      <InteractionSettingsModal
-          isOpen={isSettingsModalOpen}
-          event={relatedEvents.find((e) => e.id === editingEventId) || null}
-          onUpdate={handleEventUpdate}
-          onClose={editorActions.closeInteractionEditor} />
-
       {/* InteractionTypeSelector Modal - Render conditionally */}
       {selectedInteractionId === 'new' &&
         <div className={`fixed inset-0 ${Z_INDEX_TAILWIND.NESTED_MODAL} bg-black bg-opacity-50`} onClick={() => setSelectedInteractionId(null)}>


### PR DESCRIPTION
This commit completes the refactoring of the interaction settings UI. The functionality from the `InteractionSettingsModal` has been moved directly into the "Properties" tab of the `HotspotEditorModal`.

This addresses Issue #1 by providing a fully functional UI for editing the parameters of all interaction types, including Text, Audio, Video, Quiz, Pan/Zoom, and Spotlight. The separate settings modal has been removed in favor of this integrated approach.