### PR TITLE
I've fixed a series of [unsafe-chain] linting warnings.

### DIFF
--- a/src/client/components/FileUpload.tsx
+++ b/src/client/components/FileUpload.tsx
@@ -79,8 +79,9 @@ const FileUpload: React.FC<FileUploadProps> = ({
     event.preventDefault();
     event.stopPropagation();
     setDragOver(false);
-    if (event.dataTransfer.files && event.dataTransfer.files[0]) {
-      const file = event.dataTransfer.files[0];
+
+    const file = event.dataTransfer?.files?.[0];
+    if (file) {
       if (validateFileType(file)) {
         onFileUpload(file);
       } else {

--- a/src/client/components/HookErrorBoundary.tsx
+++ b/src/client/components/HookErrorBoundary.tsx
@@ -65,7 +65,7 @@ class HookErrorBoundary extends Component<Props, State> {
                   Error Details
                 </summary>
                 <pre className="mt-2 text-xs bg-slate-800 p-2 rounded overflow-auto max-h-32">
-                  {this.state.error.message}
+                  {this.state.error?.message}
                 </pre>
               </details>
             )}

--- a/src/client/components/ShareModal.tsx
+++ b/src/client/components/ShareModal.tsx
@@ -82,7 +82,7 @@ const ShareModal: React.FC<ShareModalProps> = ({ isOpen, onClose, project }) => 
       setCopySuccess(`Module is now ${newPublishedStatus ? 'published' : 'private'}`);
     } catch (error) {
       console.error('Failed to update published status:', error);
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      const errorMessage = error instanceof Error ? error?.message ?? 'Unknown error' : 'Unknown error';
       
       // Provide specific error messages based on error type
       if (errorMessage.includes('permission')) {

--- a/src/client/components/responsive/ResponsiveModal.tsx
+++ b/src/client/components/responsive/ResponsiveModal.tsx
@@ -64,7 +64,7 @@ export const ResponsiveModal: React.FC<ResponsiveModalProps> = ({
   
   // Touch gesture handlers for mobile bottom sheet behavior
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
-    if (!allowSwipeDown || window.innerWidth > 768) return; // Only on mobile
+    if (!allowSwipeDown || (window.innerWidth && window.innerWidth > 768)) return; // Only on mobile
     
     const touch = e.touches?.[0];
     if (!touch) return;
@@ -74,7 +74,7 @@ export const ResponsiveModal: React.FC<ResponsiveModalProps> = ({
   }, [allowSwipeDown]);
   
   const handleTouchMove = useCallback((e: React.TouchEvent) => {
-    if (!isDragging || !allowSwipeDown || window.innerWidth > 768) return;
+    if (!isDragging || !allowSwipeDown || (window.innerWidth && window.innerWidth > 768)) return;
     
     const touch = e.touches?.[0];
     if (!touch) return;

--- a/src/client/components/slides/DemoSlideDeck.ts
+++ b/src/client/components/slides/DemoSlideDeck.ts
@@ -221,7 +221,7 @@ export const convertAIStudioToSlides = (aiStudioImageUrl: string): SlideDeck => 
     
     // Update spotlight to center exactly on this position
     const spotlightEffect = welcomeHotspot.interactions?.[0]?.effect;
-    if (spotlightEffect?.type === 'spotlight') {
+    if (spotlightEffect?.type === 'spotlight' && spotlightEffect.parameters) {
       (spotlightEffect.parameters as any).position = {
         x: 705, y: 345, width: 60, height: 60  // Centered on hotspot
       };
@@ -238,7 +238,7 @@ export const convertAIStudioToSlides = (aiStudioImageUrl: string): SlideDeck => 
     
     // Update zoom to center exactly on this position
     const zoomEffect = bottomLeftHotspot.interactions?.[0]?.effect;
-    if (zoomEffect?.type === 'pan_zoom') {
+    if (zoomEffect?.type === 'pan_zoom' && zoomEffect.parameters) {
       (zoomEffect.parameters as any).targetPosition = {
         x: 35, y: 635, width: 60, height: 60  // Centered on hotspot
       };

--- a/src/client/components/slides/TimelineSlideViewer.tsx
+++ b/src/client/components/slides/TimelineSlideViewer.tsx
@@ -318,7 +318,7 @@ export const TimelineSlideViewer: React.FC<TimelineSlideViewerProps> = ({
         <SlideViewer
           ref={slideViewerRef}
           slideDeck={slideDeck}
-          {...slideDeck?.slides?.[currentSlideIndex]?.id && { initialSlideId: slideDeck.slides[currentSlideIndex].id }}
+            {...(slideDeck?.slides?.[currentSlideIndex]?.id && { initialSlideId: slideDeck?.slides?.[currentSlideIndex]?.id })}
           onSlideChange={handleSlideViewerChange}
           onInteraction={onInteraction || (() => {})}
           className="h-full"

--- a/src/client/components/slides/UnifiedSlideEditor.tsx
+++ b/src/client/components/slides/UnifiedSlideEditor.tsx
@@ -354,10 +354,10 @@ export const UnifiedSlideEditor: React.FC<UnifiedSlideEditorProps> = ({
       backgroundPosition: 'center'
     };
     if (currentSlide?.layout?.containerWidth) {
-      newSlideLayout.containerWidth = currentSlide.layout.containerWidth;
+      newSlideLayout.containerWidth = currentSlide?.layout?.containerWidth;
     }
     if (currentSlide?.layout?.containerHeight) {
-      newSlideLayout.containerHeight = currentSlide.layout.containerHeight;
+      newSlideLayout.containerHeight = currentSlide?.layout?.containerHeight;
     }
 
     const newSlide: InteractiveSlide = {
@@ -579,7 +579,7 @@ export const UnifiedSlideEditor: React.FC<UnifiedSlideEditorProps> = ({
       }
     } catch (error) {
       console.error('❌ Save error:', error);
-      actions.setError(error instanceof Error ? error.message : 'Failed to save project');
+      actions.setError(error instanceof Error ? error?.message : 'Failed to save project');
     } finally {
       actions.setSaving(false);
     }

--- a/src/client/components/views/ViewerView.tsx
+++ b/src/client/components/views/ViewerView.tsx
@@ -59,7 +59,7 @@ const ViewerView: React.FC = () => {
       setProject(fullProject);
     } catch (err: unknown) {
       console.error('Failed to load project:', err);
-      setError(`Failed to load project: ${err instanceof Error ? err.message : String(err) || 'Please try again.'}`);
+      setError(`Failed to load project: ${err instanceof Error ? err?.message : String(err) || 'Please try again.'}`);
     } finally {
       setLoading(false);
     }
@@ -84,7 +84,7 @@ const ViewerView: React.FC = () => {
 
   const handlePreviousSlide = useCallback(() => {
     if (project?.slideDeck?.slides && currentSlideIndex > 0) {
-      const prevSlideId = project.slideDeck.slides[currentSlideIndex - 1]?.id;
+      const prevSlideId = project?.slideDeck?.slides[currentSlideIndex - 1]?.id;
       if (prevSlideId) {
         handleSlideChange(prevSlideId, currentSlideIndex - 1);
       }
@@ -92,8 +92,8 @@ const ViewerView: React.FC = () => {
   }, [currentSlideIndex, project, handleSlideChange]);
 
   const handleNextSlide = useCallback(() => {
-    if (project?.slideDeck?.slides && currentSlideIndex < project.slideDeck.slides.length - 1) {
-      const nextSlideId = project.slideDeck.slides[currentSlideIndex + 1]?.id;
+    if (project?.slideDeck?.slides && currentSlideIndex < (project?.slideDeck?.slides.length ?? 0) - 1) {
+      const nextSlideId = project?.slideDeck?.slides[currentSlideIndex + 1]?.id;
       if (nextSlideId) {
         handleSlideChange(nextSlideId, currentSlideIndex + 1);
       }

--- a/src/shared/migrationUtils.ts
+++ b/src/shared/migrationUtils.ts
@@ -264,7 +264,7 @@ function convertHotspotToSlideElement(
     type: 'hotspot',
     position: createResponsivePosition(hotspot, options),
     style: {
-      backgroundColor: hotspot.color || hotspot.backgroundColor || '#3b82f6',
+      backgroundColor: hotspot?.color || hotspot?.backgroundColor || '#3b82f6',
       borderRadius: 9999, // A large number to ensure it's a circle
       zIndex: 10, // SLIDE_CONTENT level from Z_INDEX hierarchy
     },


### PR DESCRIPTION
I addressed multiple instances of deep property access without optional chaining, which could lead to runtime errors in your code. The warnings were spread across several files.

The line numbers in the original warnings were often inaccurate, so I analyzed each file to find the actual source of the issue. My fixes primarily involve adding optional chaining (`?.`) and nullish coalescing (`??`) operators to ensure that properties of potentially null or undefined objects are accessed safely.

I made changes in the following files:
- `src/client/components/HookErrorBoundary.tsx`
- `src/client/components/views/ViewerView.tsx`
- `src/client/components/ShareModal.tsx`
- `src/client/components/slides/UnifiedSlideEditor.tsx`
- `src/shared/migrationUtils.ts`
- `src/client/components/slides/DemoSlideDeck.ts`
- `src/client/components/responsive/ResponsiveModal.tsx`
- `src/client/components/FileUpload.tsx`
- `src/client/components/slides/TimelineSlideViewer.tsx`