### PR TITLE
Fix editor layout and z-index issues on mobile

### DIFF
--- a/src/client/components/slides/ResponsiveCanvas.tsx
+++ b/src/client/components/slides/ResponsiveCanvas.tsx
@@ -191,14 +191,14 @@ export const ResponsiveCanvas: React.FC<ResponsiveCanvasProps> = ({
       if (slideAreaRef.current) {
         const rect = slideAreaRef.current.getBoundingClientRect();
         setContainerDimensions({
-          width: rect.width || window.innerWidth - 64,
-          height: rect.height || window.innerHeight - 120
+          width: rect.width || window.innerWidth - 32, // More reasonable fallback
+          height: rect.height || window.innerHeight - 160 // Header(60) + Toolbar(80) + padding
         });
       } else {
         // Fallback to window dimensions
         setContainerDimensions({
-          width: window.innerWidth - 64,
-          height: window.innerHeight - 120
+          width: window.innerWidth - 32,
+          height: window.innerHeight - 160
         });
       }
     };

--- a/src/client/styles/slide-components.css
+++ b/src/client/styles/slide-components.css
@@ -906,7 +906,7 @@
   flex-shrink: 0;
   background: rgba(15, 23, 42, 0.95);
   backdrop-filter: blur(8px);
-  z-index: 9999; /* Use Z_INDEX.TOOLBAR level to appear above modals */
+  z-index: 1000; /* Use Z_INDEX.NAVIGATION level */
 }
 
 .editor-main {


### PR DESCRIPTION
This commit addresses two layout issues in the unified slide editor on mobile devices.

1.  Corrects the `z-index` of the editor header (`.editor-header`) to `1000` to resolve a stacking conflict with the editor toolbar, which was causing the toolbar to render on top of the header.
2.  Adjusts a hardcoded height calculation in the `ResponsiveCanvas` component. The previous calculation did not account for the full height of the header and toolbar, causing the canvas to render underneath the toolbar.

These changes ensure the header is always visible at the top, the toolbar is at the bottom, and the canvas content correctly fits in the space between them without overlap.