### PR TITLE
Fix: Refactor editor modals to fix critical UI/UX bugs

### DIFF
--- a/src/client/components/EnhancedModalEditorToolbar.tsx
+++ b/src/client/components/EnhancedModalEditorToolbar.tsx
@@ -204,10 +204,7 @@ const EnhancedModalEditorToolbar: React.FC<EnhancedModalEditorToolbarProps> = ({
       >
         {/* Modal Content */}
         <div 
-          className="bg-white dark:bg-slate-900 rounded-xl shadow-2xl max-w-4xl w-full overflow-hidden h-full max-h-none flex flex-col md:max-h-[90vh] md:block"
-          style={{
-            maxHeight: 'calc(100vh - env(keyboard-inset-height, 0px) - 2rem)'
-          }}
+          className="bg-white dark:bg-slate-900 rounded-xl shadow-2xl max-w-4xl w-full flex flex-col overflow-hidden h-full md:h-auto md:max-h-[calc(100vh-2rem)]"
           onClick={(e) => e.stopPropagation()}
         >
           {/* Modal Header */}
@@ -266,42 +263,8 @@ const EnhancedModalEditorToolbar: React.FC<EnhancedModalEditorToolbarProps> = ({
             </nav>
           </div>
 
-          {/* Mobile Zoom Controls Bar - Only visible on small screens */}
-          {currentZoom !== undefined && onZoomIn && onZoomOut && onZoomReset && (
-            <div className="bg-slate-100 dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 px-4 py-3 block md:hidden">
-              <div className="flex items-center justify-between">
-                <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
-                  Zoom: {Math.round(currentZoom * 100)}%
-                </span>
-                <div className="flex items-center gap-2">
-                  <button
-                    onClick={onZoomOut}
-                    className="px-3 py-1.5 bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded hover:bg-slate-300 dark:hover:bg-slate-600 transition-colors text-sm font-medium"
-                  >
-                    −
-                  </button>
-                  <button
-                    onClick={onZoomReset}
-                    className="px-3 py-1.5 bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded hover:bg-slate-300 dark:hover:bg-slate-600 transition-colors text-sm font-medium"
-                  >
-                    Reset
-                  </button>
-                  <button
-                    onClick={onZoomIn}
-                    className="px-3 py-1.5 bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 rounded hover:bg-slate-300 dark:hover:bg-slate-600 transition-colors text-sm font-medium"
-                  >
-                    +
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
-
           {/* Tab Content */}
-          <div className="p-6 overflow-y-auto flex-1 min-h-0 md:flex-none md:max-h-[60vh]"
-            style={{
-              maxHeight: 'calc(100vh - env(keyboard-inset-height, 0px) - 20rem)'
-            }}>
+          <div className="p-6 overflow-y-auto flex-1">
             {/* General Tab */}
             {activeTab === 'general' && (
               <div className="space-y-6">

--- a/src/client/components/HotspotEditorModal.tsx
+++ b/src/client/components/HotspotEditorModal.tsx
@@ -327,10 +327,9 @@ const HotspotEditorModal: React.FC<EnhancedHotspotEditorModalProps> = ({
           
           <div
             className={`
-              ${Z_INDEX_TAILWIND.SYSTEM_MODAL} bg-gray-800 text-white rounded-lg shadow-2xl
-              w-full max-w-2xl h-[80vh] max-h-[600px] flex flex-col
+              ${Z_INDEX_TAILWIND.SYSTEM_MODAL} bg-gray-800 text-white rounded-lg shadow-2xl flex flex-col
+              w-[95vw] h-[90vh] max-h-[90vh] rounded-lg
               sm:w-full sm:max-w-2xl sm:h-[80vh] sm:max-h-[600px]
-              max-sm:w-[95vw] max-sm:h-[90vh] max-sm:max-h-[90vh] max-sm:rounded-lg
               transform transition-all duration-300 ease-out
               ${isOpen ? 'scale-100 translate-y-0' : 'scale-95 translate-y-4'}
             `}


### PR DESCRIPTION
This commit fixes three critical UI/UX bugs in the editor by refactoring the styling and layout of two key modal components.

1.  **EnhancedModalEditorToolbar.tsx:**
    *   The mobile-only zoom controls, which violated the unified architecture principle, have been removed. The unified zoom controls remain accessible in the 'Controls' tab on all devices.
    *   The modal's height and overflow styling has been refactored to prevent potential double scrollbars on mobile devices, creating a more robust and consistent layout.

2.  **HotspotEditorModal.tsx:**
    *   Device-specific `max-sm:` utility classes have been removed and replaced with a standard, mobile-first responsive approach. This fixes an architectural violation and ensures the modal's styling is consistent across all screen sizes.