### PR TITLE
Fix 3 critical UI/UX bugs in the viewer

### DIFF
--- a/src/client/components/SlideBasedViewer.tsx
+++ b/src/client/components/SlideBasedViewer.tsx
@@ -97,6 +97,36 @@ const SlideBasedViewer: React.FC<SlideBasedViewerProps> = ({
     // This is a placeholder for future interaction handling logic
   }, []);
 
+  // Centralized keyboard navigation for Home/End
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (slideDeck.slides.length === 0) return;
+
+      // Ensure we're not inside an input field
+      if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+        return;
+      }
+
+      switch (event.key) {
+        case 'Home':
+          event.preventDefault();
+          handleSlideSelect(slideDeck.slides[0].id);
+          break;
+        case 'End':
+          event.preventDefault();
+          handleSlideSelect(slideDeck.slides[slideDeck.slides.length - 1].id);
+          break;
+        default:
+          break;
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [slideDeck.slides, handleSlideSelect]);
+
   // Enhanced slide deck with viewer mode settings
   const enhancedSlideDeck = useMemo(() => ({
     ...slideDeck,

--- a/src/client/components/ViewerFooterToolbar.tsx
+++ b/src/client/components/ViewerFooterToolbar.tsx
@@ -79,7 +79,6 @@ export const ViewerFooterToolbar: React.FC<ViewerFooterToolbarProps> = ({
   // Determine what buttons to show based on viewer modes
   const showExploreButton = viewerModes.explore && moduleState === 'idle';
   const showTourButton = (viewerModes.selfPaced || viewerModes.timed) && moduleState === 'idle';
-  const showBackToMenuButton = moduleState !== 'idle';
 
   const modalRef = React.useRef<HTMLDivElement>(null);
 
@@ -296,19 +295,6 @@ export const ViewerFooterToolbar: React.FC<ViewerFooterToolbarProps> = ({
               <ChevronRightIcon className="w-4 h-4" />
             </button>
 
-            {/* Back to Menu button for exploring mode */}
-            {showBackToMenuButton && (
-              <button
-                onClick={onBack}
-                className="flex items-center gap-2 bg-slate-700 hover:bg-slate-600 text-white px-4 py-2 rounded-lg font-semibold transition-colors"
-                aria-label="Back to Menu"
-              >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-                </svg>
-                <span className="hidden sm:inline">Back to Menu</span>
-              </button>
-            )}
           </div>
         )}
 

--- a/src/client/components/slides/SlideViewer.tsx
+++ b/src/client/components/slides/SlideViewer.tsx
@@ -279,22 +279,6 @@ export const SlideViewer = React.memo(forwardRef<SlideViewerRef, SlideViewerProp
           event.preventDefault();
           navigateToPrevious();
           break;
-        case 'Home':{
-            event.preventDefault();
-            const firstSlideId = slideDeck?.slides?.[0]?.id;
-            if (firstSlideId) {
-              navigateToSlide(firstSlideId);
-            }
-            break;
-          }
-        case 'End':{
-            event.preventDefault();
-            const lastSlideId = slideDeck?.slides?.[slideDeck.slides.length - 1]?.id;
-            if (lastSlideId) {
-              navigateToSlide(lastSlideId);
-            }
-            break;
-          }
         case 'Escape':
           event.preventDefault();
           setActiveEffects([]);
@@ -451,19 +435,19 @@ export const SlideViewer = React.memo(forwardRef<SlideViewerRef, SlideViewerProp
             {currentSlide.backgroundMedia.type === 'youtube' && currentSlide.backgroundMedia.youtubeId &&
           <div className="absolute inset-0 w-full h-full">
                 <iframe
-              src={`https://www.youtube.com/embed/${currentSlide.backgroundMedia.youtubeId}?autoplay=${
-              currentSlide.backgroundMedia.autoplay ? 1 : 0}&loop=${
-
-              currentSlide.backgroundMedia.loop ? 1 : 0}&mute=${
-
-              currentSlide.backgroundMedia.muted ? 1 : 0}&controls=${
-
-              currentSlide.backgroundMedia.controls ? 1 : 0}&start=${
-
-              currentSlide.backgroundMedia.startTime || 0}&end=${
-
-              currentSlide.backgroundMedia.endTime || ''}&rel=0&modestbranding=1&playsinline=1`
-              }
+              src={`https://www.youtube.com/embed/${
+                currentSlide.backgroundMedia.youtubeId
+              }?autoplay=${currentSlide.backgroundMedia.autoplay ? 1 : 0}&loop=${
+                currentSlide.backgroundMedia.loop ? 1 : 0
+              }&mute=${currentSlide.backgroundMedia.muted ? 1 : 0}&controls=${
+                currentSlide.backgroundMedia.controls ? 1 : 0
+              }&start=${currentSlide.backgroundMedia.startTime || 0}&end=${
+                currentSlide.backgroundMedia.endTime || ''
+              }&rel=0&modestbranding=1&playsinline=1${
+                currentSlide.backgroundMedia.loop
+                  ? `&playlist=${currentSlide.backgroundMedia.youtubeId}`
+                  : ''
+              }`}
               className="absolute inset-0 w-full h-full"
               allow="autoplay; encrypted-media"
               allowFullScreen

--- a/src/tests/ViewerFooterToolbar.test.tsx
+++ b/src/tests/ViewerFooterToolbar.test.tsx
@@ -202,11 +202,6 @@ const mockAuth = {
         expect(mockOnStartLearning).toHaveBeenCalledTimes(1);
       });
 
-      it('renders "Back to Menu" button in learning/exploring state', () => {
-          renderWithAuthProvider(<ViewerFooterToolbar {...defaultProps} moduleState="exploring" />);
-          expect(screen.getByRole('button', { name: /Back to Menu/i })).toBeInTheDocument();
-      });
-
       it('opens and closes the keyboard shortcuts modal', () => {
         renderWithAuthProvider(<ViewerFooterToolbar {...defaultProps} />);
         const shortcutsButton = screen.getByRole('button', { name: /Show keyboard shortcuts/i });
@@ -244,10 +239,6 @@ const mockAuth = {
         expect(screen.getByRole('button', { name: 'Guided Tour' })).toBeInTheDocument();
       });
 
-      it('renders "Menu" button in learning/exploring state', () => {
-          renderWithAuthProvider(<ViewerFooterToolbar {...mobileProps} moduleState="exploring" />);
-          expect(screen.getByRole('button', { name: /Menu/i })).toBeInTheDocument();
-      });
     });
 
     describe('Accessibility', () => {


### PR DESCRIPTION
This commit fixes three distinct bugs in the slide viewer:

1.  **Non-functional keyboard shortcuts:** The Home and End keys for navigating to the first and last slides were not working correctly. The logic has been centralized in the `SlideBasedViewer` component to ensure they work globally and consistently.

2.  **Inconsistent "Back to Menu" button:** A redundant "Back to Menu" button was appearing in the center of the toolbar in "exploring" mode, creating a confusing user experience. This button has been removed to provide a single, consistent "Back" button in the top-left corner.

3.  **YouTube video looping:** YouTube videos used as slide backgrounds were not looping as intended. This has been fixed by adding the required `playlist` parameter to the YouTube embed URL.

The corresponding tests for the removed button have also been deleted.