### PR TITLE
feat: Implemented slide preview and interaction rendering

### DIFF
--- a/src/client/components/EnhancedModalEditorToolbar.tsx
+++ b/src/client/components/EnhancedModalEditorToolbar.tsx
@@ -19,6 +19,7 @@ interface EnhancedModalEditorToolbarProps {
   onClose: () => void;
   projectName: string;
   onBack: () => void;
+  onLivePreview: () => void;
   onReplaceImage: (file: File) => void;
   
   // Auto-progression
@@ -103,6 +104,7 @@ const EnhancedModalEditorToolbar: React.FC<EnhancedModalEditorToolbarProps> = ({
   onClose,
   projectName,
   onBack,
+  onLivePreview,
   onReplaceImage,
   isAutoProgression,
   onToggleAutoProgression,
@@ -210,6 +212,12 @@ const EnhancedModalEditorToolbar: React.FC<EnhancedModalEditorToolbarProps> = ({
           {/* Modal Header */}
           <div className="flex items-center justify-between p-6 border-b border-slate-200 dark:border-slate-700">
             <div className="flex items-center gap-4">
+              <button
+                onClick={onLivePreview}
+                className="flex items-center gap-2 text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white transition-colors"
+              >
+                <span className="font-medium">Live Preview</span>
+              </button>
               <button
                 onClick={onBack}
                 className="flex items-center gap-2 text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white transition-colors"

--- a/src/client/components/InteractionOverlay.tsx
+++ b/src/client/components/InteractionOverlay.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ElementInteraction } from '../../shared/slideTypes';
+import { ElementInteraction, ShowTextParameters } from '../../shared/slideTypes';
 
 interface InteractionOverlayProps {
   interactions: ElementInteraction[];
@@ -13,14 +13,20 @@ const InteractionOverlay: React.FC<InteractionOverlayProps> = ({ interactions, o
 
   return (
     <div className="absolute inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-      {interactions.map((interaction) => (
-        <div key={interaction.id} className="bg-white p-4 rounded-lg shadow-lg">
-          <p>{interaction.action.payload.text}</p>
-          <button onClick={() => onClose(interaction.id)} className="mt-4 px-4 py-2 bg-blue-500 text-white rounded">
-            Close
-          </button>
-        </div>
-      ))}
+      {interactions.map((interaction) => {
+        if (interaction.effect.type !== 'text') {
+          return null;
+        }
+        const params = interaction.effect.parameters as ShowTextParameters;
+        return (
+          <div key={interaction.id} className="bg-white p-4 rounded-lg shadow-lg">
+            <p>{params.text}</p>
+            <button onClick={() => onClose(interaction.id)} className="mt-4 px-4 py-2 bg-blue-500 text-white rounded">
+              Close
+            </button>
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/client/components/InteractionOverlay.tsx
+++ b/src/client/components/InteractionOverlay.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { ElementInteraction } from '../../shared/slideTypes';
+
+interface InteractionOverlayProps {
+  interactions: ElementInteraction[];
+  onClose: (interactionId: string) => void;
+}
+
+const InteractionOverlay: React.FC<InteractionOverlayProps> = ({ interactions, onClose }) => {
+  if (interactions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="absolute inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      {interactions.map((interaction) => (
+        <div key={interaction.id} className="bg-white p-4 rounded-lg shadow-lg">
+          <p>{interaction.action.payload.text}</p>
+          <button onClick={() => onClose(interaction.id)} className="mt-4 px-4 py-2 bg-blue-500 text-white rounded">
+            Close
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default InteractionOverlay;

--- a/src/client/components/SlideBasedViewer.tsx
+++ b/src/client/components/SlideBasedViewer.tsx
@@ -102,7 +102,7 @@ const SlideBasedViewer: React.FC<SlideBasedViewerProps> = ({
 
   // Interaction handler
   const handleInteraction = useCallback((interaction: ElementInteraction) => {
-    if (interaction.action.type === 'show-text') {
+    if (interaction.effect.type === 'text') {
       setActiveInteractions((prev) => [...prev, interaction]);
     }
   }, []);

--- a/src/client/components/SlideBasedViewer.tsx
+++ b/src/client/components/SlideBasedViewer.tsx
@@ -7,6 +7,7 @@ import { Z_INDEX_TAILWIND } from '../utils/zIndexLevels';
 import { SlideViewer } from './slides/SlideViewer';
 import TimelineSlideViewer from './slides/TimelineSlideViewer';
 import ViewerFooterToolbar from './ViewerFooterToolbar';
+import InteractionOverlay from './InteractionOverlay';
 
 interface SlideBasedViewerProps {
   slideDeck: SlideDeck;
@@ -39,6 +40,7 @@ const SlideBasedViewer: React.FC<SlideBasedViewerProps> = ({
     slideDeck.slides && slideDeck.slides.length > 0 ? slideDeck.slides[0]?.id || '' : ''
   );
   const [currentSlideIndex, setCurrentSlideIndex] = useState(0);
+  const [activeInteractions, setActiveInteractions] = useState<ElementInteraction[]>([]);
 
   // Navigation handlers for footer toolbar
   const handlePreviousSlide = useCallback(() => {
@@ -99,8 +101,14 @@ const SlideBasedViewer: React.FC<SlideBasedViewerProps> = ({
   }, [slideDeck.slides, handleSlideChange]);
 
   // Interaction handler
-  const handleInteraction = useCallback((_interaction: ElementInteraction) => {
-    // This is a placeholder for future interaction handling logic
+  const handleInteraction = useCallback((interaction: ElementInteraction) => {
+    if (interaction.action.type === 'show-text') {
+      setActiveInteractions((prev) => [...prev, interaction]);
+    }
+  }, []);
+
+  const handleCloseInteraction = useCallback((interactionId: string) => {
+    setActiveInteractions((prev) => prev.filter((i) => i.id !== interactionId));
   }, []);
 
   // Centralized keyboard navigation for Home/End
@@ -196,7 +204,8 @@ const SlideBasedViewer: React.FC<SlideBasedViewerProps> = ({
   }
 
   return (
-    <div className="w-screen h-[calc(var(--vh,1vh)*100)] flex flex-col bg-gradient-to-br from-slate-900 to-slate-800">
+    <div className="w-screen h-[calc(var(--vh,1vh)*100)] flex flex-col bg-gradient-to-br from-slate-900 to-slate-800 relative">
+      <InteractionOverlay interactions={activeInteractions} onClose={handleCloseInteraction} />
       {/* Slide viewer content area - use flex-1 for proper sizing */}
       <div className="flex-1 overflow-auto">
         {moduleState === 'learning' && (viewerModes.selfPaced || viewerModes.timed) ?

--- a/src/client/components/SlideEditorToolbar.tsx
+++ b/src/client/components/SlideEditorToolbar.tsx
@@ -4,6 +4,8 @@ import { Z_INDEX_TAILWIND } from '../utils/zIndexLevels';
 import AuthButton from './AuthButton';
 import { CheckIcon } from './icons/CheckIcon';
 import { ChevronLeftIcon } from './icons/ChevronLeftIcon';
+import { EyeIcon } from './icons/EyeIcon';
+import { ExternalLinkIcon } from './icons/ExternalLinkIcon';
 import { GearIcon } from './icons/GearIcon';
 import { SaveIcon } from './icons/SaveIcon';
 import { ShareIcon } from './icons/ShareIcon';
@@ -17,6 +19,9 @@ interface SlideEditorToolbarProps {
   isPublished: boolean;
   onImageUpload: (file: File) => void;
   project?: Project;
+  onTogglePreview: () => void;
+  onLivePreview: () => void;
+  isPreview: boolean;
 }
 
 /**
@@ -32,7 +37,10 @@ const SlideEditorToolbar: React.FC<SlideEditorToolbarProps> = ({
   isSaving,
   isPublished,
   onImageUpload: _onImageUpload,
-  project
+  project,
+  onTogglePreview,
+  onLivePreview,
+  isPreview
 }) => {
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
   const [showSuccessMessage, setShowSuccessMessage] = useState(false);
@@ -85,6 +93,26 @@ const SlideEditorToolbar: React.FC<SlideEditorToolbarProps> = ({
 
           {/* Right: Actions */}
           <div className="flex items-center gap-1 md:gap-3">
+            <button
+              onClick={onTogglePreview}
+              className={`flex items-center gap-1 md:gap-2 p-2 md:px-4 md:py-2 text-slate-300 md:text-white hover:text-white transition-colors rounded-lg hover:bg-slate-700 md:font-medium ${
+                isPreview ? 'md:bg-blue-700' : 'md:bg-blue-600 md:hover:bg-blue-700'
+              }`}
+              aria-label="Toggle preview"
+            >
+              <EyeIcon className="w-4 h-4" />
+              <span className="hidden md:inline">{isPreview ? 'Editing' : 'Preview'}</span>
+            </button>
+
+            <button
+              onClick={onLivePreview}
+              className="flex items-center gap-1 md:gap-2 p-2 md:px-4 md:py-2 text-slate-300 md:text-white hover:text-white transition-colors rounded-lg hover:bg-slate-700 md:bg-teal-600 md:hover:bg-teal-700 md:font-medium"
+              aria-label="Live preview"
+            >
+              <ExternalLinkIcon className="w-4 h-4" />
+              <span className="hidden md:inline">Live Preview</span>
+            </button>
+
             {/* Save Button - responsive design */}
             <button
               onClick={handleSave}

--- a/src/client/components/icons/ExternalLinkIcon.tsx
+++ b/src/client/components/icons/ExternalLinkIcon.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export const ExternalLinkIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+    <polyline points="15 3 21 3 21 9" />
+    <line x1="10" y1="14" x2="21" y2="3" />
+  </svg>
+);

--- a/src/client/components/responsive/ResponsiveHeader.tsx
+++ b/src/client/components/responsive/ResponsiveHeader.tsx
@@ -15,6 +15,7 @@ import { GearIcon } from '../icons/GearIcon';
 import { PencilIcon } from '../icons/PencilIcon';
 import { SaveIcon } from '../icons/SaveIcon';
 import { ShareIcon } from '../icons/ShareIcon';
+import { ExternalLinkIcon } from '../icons/ExternalLinkIcon';
 
 export interface ResponsiveHeaderProps {
   projectName: string;
@@ -23,6 +24,7 @@ export interface ResponsiveHeaderProps {
   errorMessage: string | null;
   showSuccessMessage: boolean;
   onTogglePreview: () => void;
+  onLivePreview: () => void;
   onSave: () => void;
   onClose: () => void;
   onOpenSettings: () => void;
@@ -40,6 +42,7 @@ export const ResponsiveHeader: React.FC<ResponsiveHeaderProps> = ({
   errorMessage,
   showSuccessMessage,
   onTogglePreview,
+  onLivePreview,
   onSave,
   onClose,
   onOpenSettings,
@@ -105,6 +108,18 @@ export const ResponsiveHeader: React.FC<ResponsiveHeaderProps> = ({
         
         {/* Right section - Actions */}
         <div className="flex items-center gap-1 sm:gap-3">
+          {/* Live Preview button */}
+          {!isPreviewMode && (
+            <button
+              onClick={onLivePreview}
+              className="flex items-center gap-1 sm:gap-2 px-2 sm:px-4 py-2 rounded-lg font-medium transition-all text-xs sm:text-sm bg-teal-600 text-white hover:bg-teal-700"
+              title="Live Preview"
+            >
+              <ExternalLinkIcon className="w-4 h-4" />
+              <span className="hidden sm:inline">Live Preview</span>
+            </button>
+          )}
+
           {/* Preview toggle */}
           <button
             onClick={onTogglePreview}

--- a/src/client/components/slides/SlidePreview.tsx
+++ b/src/client/components/slides/SlidePreview.tsx
@@ -11,7 +11,7 @@ interface SlidePreviewProps {
 const SlidePreview: React.FC<SlidePreviewProps> = ({ slideDeck, projectName, onClose }) => {
   return (
     <div className="absolute inset-0 bg-black bg-opacity-75 z-50 flex items-center justify-center">
-      <div className="w-full h-full max-w-4xl max-h-4xl bg-white rounded-lg overflow-hidden shadow-2xl">
+      <div className="w-full h-full max-w-4xl max-h-[80vh] bg-white rounded-lg overflow-hidden shadow-2xl">
         <SlideBasedViewer
           slideDeck={slideDeck}
           projectName={projectName}

--- a/src/client/components/slides/SlidePreview.tsx
+++ b/src/client/components/slides/SlidePreview.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { SlideDeck } from '../../../shared/slideTypes';
+import SlideBasedViewer from '../SlideBasedViewer';
+
+interface SlidePreviewProps {
+  slideDeck: SlideDeck;
+  projectName: string;
+  onClose: () => void;
+}
+
+const SlidePreview: React.FC<SlidePreviewProps> = ({ slideDeck, projectName, onClose }) => {
+  return (
+    <div className="absolute inset-0 bg-black bg-opacity-75 z-50 flex items-center justify-center">
+      <div className="w-full h-full max-w-4xl max-h-4xl bg-white rounded-lg overflow-hidden shadow-2xl">
+        <SlideBasedViewer
+          slideDeck={slideDeck}
+          projectName={projectName}
+          viewerModes={{ explore: true, selfPaced: false, timed: false }}
+          autoStart={true}
+          onClose={onClose}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default SlidePreview;

--- a/src/client/components/slides/UnifiedSlideEditor.tsx
+++ b/src/client/components/slides/UnifiedSlideEditor.tsx
@@ -405,6 +405,7 @@ export const UnifiedSlideEditor: React.FC<UnifiedSlideEditorProps> = ({
 
     const updatedSlideDeck = { ...slideDeck, slides: updatedSlides };
     handleSlideDeckUpdate(updatedSlideDeck);
+    actions.setCurrentSlide(insertIndex);
   }, [slideDeck, state.navigation.currentSlideIndex, currentSlide, handleSlideDeckUpdate, actions]);
 
   // Handle duplicating slides

--- a/src/client/components/slides/UnifiedSlideEditor.tsx
+++ b/src/client/components/slides/UnifiedSlideEditor.tsx
@@ -34,6 +34,7 @@ import { ResponsiveSlidesModal } from '../responsive/ResponsiveSlidesModal';
 import { ResponsiveToolbar } from '../responsive/ResponsiveToolbar';
 import { ObjectEditorPanel } from './ObjectEditorPanel';
 import { ResponsiveCanvas } from './ResponsiveCanvas';
+import SlidePreview from './SlidePreview';
 // Mobile toolbar hooks removed - functionality moved to responsive design
 
 // Import responsive components and modals (to be created)
@@ -404,7 +405,6 @@ export const UnifiedSlideEditor: React.FC<UnifiedSlideEditorProps> = ({
 
     const updatedSlideDeck = { ...slideDeck, slides: updatedSlides };
     handleSlideDeckUpdate(updatedSlideDeck);
-    actions.setCurrentSlide(insertIndex);
   }, [slideDeck, state.navigation.currentSlideIndex, currentSlide, handleSlideDeckUpdate, actions]);
 
   // Handle duplicating slides
@@ -647,6 +647,11 @@ export const UnifiedSlideEditor: React.FC<UnifiedSlideEditorProps> = ({
     }
   }), [slideDeck]);
 
+  const handleLivePreview = useCallback(() => {
+    const previewUrl = `/preview/${projectId}`;
+    window.open(previewUrl, '_blank');
+  }, [projectId]);
+
   return (
     <ProjectThemeProvider
       {...projectTheme && { initialThemeId: projectTheme }}
@@ -663,6 +668,7 @@ export const UnifiedSlideEditor: React.FC<UnifiedSlideEditorProps> = ({
             errorMessage={state.operations.error}
             showSuccessMessage={state.ui.showSuccessMessage}
             onTogglePreview={actions.togglePreviewMode}
+            onLivePreview={handleLivePreview}
             onSave={handleSave}
             onClose={onClose}
             onOpenSettings={() => actions.openModal('settingsModal')}
@@ -670,9 +676,17 @@ export const UnifiedSlideEditor: React.FC<UnifiedSlideEditorProps> = ({
             isPublished={isPublished} />
         </div>
 
+        {state.navigation.isPreviewMode && (
+          <SlidePreview
+            slideDeck={slideDeck}
+            projectName={projectName}
+            onClose={actions.togglePreviewMode}
+          />
+        )}
+
         {/* Main editor content */}
-        <div className="editor-main flex-1 flex overflow-hidden 
-                        md:flex-row flex-col">
+        <div className={`editor-main flex-1 flex overflow-hidden
+                        md:flex-row flex-col ${state.navigation.isPreviewMode ? 'blur-sm' : ''}`}>
           
           {/* Main canvas area */}
           <div className="flex-1 flex flex-col relative min-h-0" ref={canvasContainerRef}>

--- a/src/tests/coreFunctionality/UnifiedSlideEditor.test.tsx
+++ b/src/tests/coreFunctionality/UnifiedSlideEditor.test.tsx
@@ -170,12 +170,11 @@ describe('UnifiedSlideEditor', () => {
 
     await waitFor(() => {
         expect(onSlideDeckChange).toHaveBeenCalled();
+        const updatedDeck = onSlideDeckChange.mock.calls[0]?.[0] as SlideDeck;
+        if (updatedDeck) {
+            expect(updatedDeck.slides!).toHaveLength(2);
+        }
     });
-
-    const updatedDeck = onSlideDeckChange.mock.calls[0]?.[0] as SlideDeck;
-    if (updatedDeck) {
-        expect(updatedDeck.slides!).toHaveLength(2);
-    }
   });
 
   test('saves the project when save button is clicked', async () => {


### PR DESCRIPTION
This commit introduces the following features:
- A "Preview" button in the slide editor toolbar that toggles a preview mode.
- A "Live Preview" button that opens the slide viewer in a new tab.
- The interaction events are now rendered in the viewer.
- The `handleInteraction` function in `SlideBasedViewer.tsx` is now implemented to handle "show-text" interactions.