### PR TITLE
fix: Use dynamic viewport height to prevent collapsing UI

### DIFF
--- a/src/client/components/App.tsx
+++ b/src/client/components/App.tsx
@@ -24,7 +24,7 @@ import ViewerView from './views/ViewerView';
 
 
 const LoadingScreen: React.FC = () => (
-  <div className="min-h-screen flex items-center justify-center">
+  <div className="min-h-screen-dynamic flex items-center justify-center">
     <div className="text-center">
       <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto" />
       <p className="mt-4 text-gray-600">Loading...</p>
@@ -418,7 +418,7 @@ const MainApp: React.FC = () => {
   }
 
   return (
-    <div className={`min-h-screen bg-gradient-to-br from-slate-900 to-slate-800 text-white transition-all duration-2000 ${showInitialAnimation ? 'scale-105 opacity-95' : 'scale-100 opacity-100'}`} style={{ paddingTop: 'max(env(safe-area-inset-top), 16px)', paddingLeft: '16px', paddingRight: '16px', paddingBottom: '16px' }}>
+    <div className={`min-h-screen-dynamic bg-gradient-to-br from-slate-900 to-slate-800 text-white transition-all duration-2000 ${showInitialAnimation ? 'scale-105 opacity-95' : 'scale-100 opacity-100'}`} style={{ paddingTop: 'max(env(safe-area-inset-top), 16px)', paddingLeft: '16px', paddingRight: '16px', paddingBottom: '16px' }}>
       <header className="mb-6 sm:mb-8 text-center" style={{ paddingTop: '16px' }}>
         <div className="max-w-6xl mx-auto">
           <div className="block sm:hidden">
@@ -558,7 +558,7 @@ const AuthenticatedApp: React.FC = () => {
   }
 
   return (
-    <div className="h-screen bg-gray-50 overflow-hidden" style={{ paddingTop: 'max(env(safe-area-inset-top), 0px)', paddingBottom: 'max(env(safe-area-inset-bottom), 0px)' }}>
+    <div className="h-screen-dynamic bg-gray-50 overflow-hidden" style={{ paddingTop: 'max(env(safe-area-inset-top), 0px)', paddingBottom: 'max(env(safe-area-inset-bottom), 0px)' }}>
       <main>
         <MainApp />
       </main>
@@ -577,7 +577,7 @@ const App: React.FC = () => {
           <Route path="/" element={<AuthenticatedApp />} />
           <Route path="/view/:projectId" element={<ViewerView />} />
           <Route path="/shared/:moduleId" element={
-            <div className="min-h-screen bg-gray-50">
+            <div className="min-h-screen-dynamic bg-gray-50">
               <main>
                 <SharedModuleViewer />
               </main>

--- a/src/client/components/EditorTestPage.tsx
+++ b/src/client/components/EditorTestPage.tsx
@@ -128,7 +128,7 @@ export const EditorTestPage: React.FC = () => {
   }, []);
 
   return (
-    <div className="mobile-editor-test min-h-screen bg-slate-900 text-white flex flex-col">
+    <div className="mobile-editor-test min-h-screen-dynamic bg-slate-900 text-white flex flex-col">
       {/* Header with mode switching and debug info */}
       <div className="bg-slate-800 border-b border-slate-700 p-4 flex-shrink-0">
         <div className="flex items-center justify-between mb-3">

--- a/src/client/components/HookErrorBoundary.tsx
+++ b/src/client/components/HookErrorBoundary.tsx
@@ -53,7 +53,7 @@ class HookErrorBoundary extends Component<Props, State> {
   override render() {
     if (this.state.hasError) {
       return this.props.fallback || (
-        <div className="flex items-center justify-center min-h-screen bg-slate-900 text-white">
+        <div className="flex items-center justify-center min-h-screen-dynamic bg-slate-900 text-white">
           <div className="text-center p-8 max-w-md">
             <h2 className="text-2xl font-bold mb-4 text-red-400">Component Error</h2>
             <p className="text-slate-300 mb-4">

--- a/src/client/components/ScrollStacks.tsx
+++ b/src/client/components/ScrollStacks.tsx
@@ -65,7 +65,7 @@ const ScrollStacks: React.FC<ScrollStacksProps> = ({ projects, onEdit, onDelete 
   return (
     <div 
       ref={containerRef}
-      className="relative min-h-screen"
+      className="relative min-h-screen-dynamic"
     >
       {projects.map((project, index) => {
         const isVisible = visibleCards.includes(index);

--- a/src/client/components/SharedModuleViewer.tsx
+++ b/src/client/components/SharedModuleViewer.tsx
@@ -95,7 +95,7 @@ const SharedModuleViewer: React.FC<SharedModuleViewerProps> = () => {
 
   if (isLoading) {
     return (
-      <div className={`min-h-screen flex items-center justify-center ${baseBgColor} ${baseTextColor} p-4`} style={{ paddingTop: 'max(env(safe-area-inset-top), 16px)', paddingBottom: 'max(env(safe-area-inset-bottom), 16px)' }}>
+      <div className={`min-h-screen-dynamic flex items-center justify-center ${baseBgColor} ${baseTextColor} p-4`} style={{ paddingTop: 'max(env(safe-area-inset-top), 16px)', paddingBottom: 'max(env(safe-area-inset-bottom), 16px)' }}>
         <div className="flex flex-col items-center space-y-4">
           <svg className={`animate-spin h-10 w-10 text-${accentColor}`} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
             <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
@@ -110,7 +110,7 @@ const SharedModuleViewer: React.FC<SharedModuleViewerProps> = () => {
 
   if (error) {
     return (
-      <div className={`min-h-screen flex items-center justify-center ${baseBgColor} ${baseTextColor} p-4`} style={{ paddingTop: 'max(env(safe-area-inset-top), 16px)', paddingBottom: 'max(env(safe-area-inset-bottom), 16px)' }}>
+      <div className={`min-h-screen-dynamic flex items-center justify-center ${baseBgColor} ${baseTextColor} p-4`} style={{ paddingTop: 'max(env(safe-area-inset-top), 16px)', paddingBottom: 'max(env(safe-area-inset-bottom), 16px)' }}>
         <div className={`text-center max-w-lg mx-auto p-6 sm:p-8 rounded-xl shadow-2xl ${cardBgColor} border ${cardBorderColor}`}>
           <div className={`mb-5 text-red-500 dark:text-red-400`}>
             <svg className="w-16 h-16 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="1.5">
@@ -135,14 +135,14 @@ const SharedModuleViewer: React.FC<SharedModuleViewerProps> = () => {
   if (!project) {
     // This case should ideally be covered by error state, but good for robustness
     return (
-      <div className={`min-h-screen flex items-center justify-center ${baseBgColor} ${baseTextColor}`} style={{ paddingTop: 'max(env(safe-area-inset-top), 16px)', paddingBottom: 'max(env(safe-area-inset-bottom), 16px)' }}>
+      <div className={`min-h-screen-dynamic flex items-center justify-center ${baseBgColor} ${baseTextColor}`} style={{ paddingTop: 'max(env(safe-area-inset-top), 16px)', paddingBottom: 'max(env(safe-area-inset-bottom), 16px)' }}>
             <p>Module data is not available.</p>
         </div>);
 
   }
 
   return (
-    <div className={`flex flex-col min-h-screen ${baseBgColor} ${baseTextColor} ${isEmbedMode ? 'h-screen overflow-hidden' : 'relative'}`} style={{ paddingTop: 'max(env(safe-area-inset-top), 0px)', paddingBottom: 'max(env(safe-area-inset-bottom), 0px)' }}>
+    <div className={`flex flex-col min-h-screen-dynamic ${baseBgColor} ${baseTextColor} ${isEmbedMode ? 'h-screen-dynamic overflow-hidden' : 'relative'}`} style={{ paddingTop: 'max(env(safe-area-inset-top), 0px)', paddingBottom: 'max(env(safe-area-inset-bottom), 0px)' }}>
       <a
         href="#main-content"
         className={`skip-to-main-content-link ${theme === 'light' ? 'bg-gray-200 text-gray-800 border-gray-400 hover:bg-gray-300' : 'bg-slate-700 text-slate-100 border-slate-600 hover:bg-slate-600'}`}>

--- a/src/client/components/SlideBasedTestPage.tsx
+++ b/src/client/components/SlideBasedTestPage.tsx
@@ -11,7 +11,7 @@ export const SlideBasedTestPage: React.FC = () => {
   const [showComparison, setShowComparison] = useState(false);
 
   return (
-    <div className="slide-based-test-page w-full h-screen-dynamic flex flex-col bg-gradient-to-br from-slate-900 to-slate-800">
+    <div className="slide-based-test-page w-screen h-screen-dynamic flex flex-col bg-gradient-to-br from-slate-900 to-slate-800">
       {/* Header - Matches app header styling */}
       <div className="test-header bg-slate-800 border-b border-slate-700 text-white p-4 flex items-center justify-between flex-shrink-0 shadow-2xl">
         <div className="flex items-center space-x-4">

--- a/src/client/components/SlideBasedTestPage.tsx
+++ b/src/client/components/SlideBasedTestPage.tsx
@@ -11,7 +11,7 @@ export const SlideBasedTestPage: React.FC = () => {
   const [showComparison, setShowComparison] = useState(false);
 
   return (
-    <div className="slide-based-test-page w-screen h-screen flex flex-col bg-gradient-to-br from-slate-900 to-slate-800">
+    <div className="slide-based-test-page w-full h-screen-dynamic flex flex-col bg-gradient-to-br from-slate-900 to-slate-800">
       {/* Header - Matches app header styling */}
       <div className="test-header bg-slate-800 border-b border-slate-700 text-white p-4 flex items-center justify-between flex-shrink-0 shadow-2xl">
         <div className="flex items-center space-x-4">

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -29,6 +29,21 @@ body {
   touch-action: manipulation;
 }
 
+/*
+ * Dynamic screen height utilities.
+ * These use the --vh custom property set by the useViewportHeight hook
+ * to correctly handle mobile browser UI elements that can shrink the viewport.
+ */
+.min-h-screen-dynamic {
+  min-height: 100vh; /* Fallback for browsers that don't support custom properties */
+  min-height: calc(var(--vh, 1vh) * 100);
+}
+
+.h-screen-dynamic {
+  height: 100vh; /* Fallback */
+  height: calc(var(--vh, 1vh) * 100);
+}
+
 
 /* Hotspot Editor Toolbar specific styles if needed beyond Tailwind */
 .toolbar-scroll::-webkit-scrollbar {

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -31,17 +31,29 @@ body {
 
 /*
  * Dynamic screen height utilities.
- * These use the --vh custom property set by the useViewportHeight hook
+ * These use the --vh custom property set by the setDynamicViewportProperties utility
  * to correctly handle mobile browser UI elements that can shrink the viewport.
  */
 .min-h-screen-dynamic {
-  min-height: 100vh; /* Fallback for browsers that don't support custom properties */
-  min-height: calc(var(--vh, 1vh) * 100);
+  min-height: 100vh; /* Fallback for older browsers */
+  min-height: calc(var(--vh, 1vh) * 100); /* JS-based fallback */
 }
 
 .h-screen-dynamic {
-  height: 100vh; /* Fallback */
-  height: calc(var(--vh, 1vh) * 100);
+  height: 100vh; /* Fallback for older browsers */
+  height: calc(var(--vh, 1vh) * 100); /* JS-based fallback */
+}
+
+@supports (min-height: 100dvh) {
+  .min-h-screen-dynamic {
+    min-height: 100dvh; /* Modern CSS solution */
+  }
+}
+
+@supports (height: 100dvh) {
+  .h-screen-dynamic {
+    height: 100dvh; /* Modern CSS solution */
+  }
 }
 
 


### PR DESCRIPTION
On mobile browsers, using '100vh' for height causes layout issues when the browser's UI (like the address bar) appears or disappears. This was causing elements to be sized incorrectly, leading to CSS collapsing or unwanted scrolling.

This commit introduces dynamic viewport height utility classes (`.h-screen-dynamic` and `.min-h-screen-dynamic`) that use a CSS custom property (`--vh`) for height calculations.

The `--vh` variable is set globally by the `setDynamicViewportProperties` utility, which listens for viewport changes and ensures the layout correctly adapts to the visible area on all devices.

All instances of Tailwind's `h-screen` and `min-h-screen` have been replaced with these new, more robust utility classes.