### PR TITLE
Fix all TypeScript errors

### DIFF
--- a/src/client/components/slides/canvas/CanvasContainer.tsx
+++ b/src/client/components/slides/canvas/CanvasContainer.tsx
@@ -6,7 +6,7 @@ import { ViewportBounds } from '../../../utils/touchUtils';
 interface CanvasContainerProps {
   children: React.ReactNode;
   canvasTransform: ImageTransformState;
-  setCanvasTransform: (transform: ImageTransformState | ((prevTransform: ImageTransformState) => ImageTransformState)) => void;
+  setCanvasTransform: React.Dispatch<React.SetStateAction<ImageTransformState>>;
   isTransforming: boolean;
   setIsTransforming: (isTransforming: boolean) => void;
   viewportBounds: ViewportBounds;

--- a/src/client/components/slides/canvas/CanvasContainer.tsx
+++ b/src/client/components/slides/canvas/CanvasContainer.tsx
@@ -6,7 +6,7 @@ import { ViewportBounds } from '../../../utils/touchUtils';
 interface CanvasContainerProps {
   children: React.ReactNode;
   canvasTransform: ImageTransformState;
-  setCanvasTransform: (transform: ImageTransformState) => void;
+  setCanvasTransform: (transform: ImageTransformState | ((prevTransform: ImageTransformState) => ImageTransformState)) => void;
   isTransforming: boolean;
   setIsTransforming: (isTransforming: boolean) => void;
   viewportBounds: ViewportBounds;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,7 +39,7 @@
     "strictPropertyInitialization": true,
 
     /* CSS imports support */
-    "types": ["vite/client", "@types/react", "@types/react-dom", "jest"],
+    "types": ["vite/client", "@types/react", "@types/react-dom", "vitest/globals"],
 
     "paths": {
       "@/*" :  ["./*"]


### PR DESCRIPTION
This change resolves all TypeScript errors in the codebase.

The following changes were made:
- Removed "jest" from `compilerOptions.types` in `tsconfig.json` as the project uses `vitest`.
- Added "vitest/globals" to `compilerOptions.types` in `tsconfig.json` to make `vitest` globals available in all files.
- Updated the type of the `setCanvasTransform` prop in `CanvasContainer.tsx` to be compatible with React's state setter function type.

All changes were verified by running the `typecheck` command and the test suite.